### PR TITLE
Start using `thiserror` for errors in the library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ futures-util = "0.3.30"
 tungstenite = { version = "0.24.0", features = ["native-tls"] }
 url = "2.5.2"
 http = "1.1.0"
-
+thiserror = "2.0.4"
 
 [dev-dependencies]
 dotenvy = "0.15.7"

--- a/src/client/feature_proxy.rs
+++ b/src/client/feature_proxy.rs
@@ -24,7 +24,7 @@ use crate::{
 
 use crate::entity::Entity;
 
-use super::cache::ConfigurationAccessError;
+use crate::errors::ConfigurationAccessError;
 
 const MISSING_FEATURE_ERROR_MSG: &str = "The feature should exist in the configuration_snapshot. It should have been validated in `AppConfigurationClient::get_feature()`.";
 

--- a/src/client/property.rs
+++ b/src/client/property.rs
@@ -15,12 +15,9 @@
 use crate::client::value::{NumericValue, Value};
 use crate::entity::Entity;
 use std::collections::HashMap;
-use std::error::Error;
 
-use super::app_configuration_client::AppConfigurationClientError;
+use crate::errors::{Error, Result};
 use crate::segment_evaluation::find_applicable_segment_rule_for_entity;
-
-type Result<T> = std::result::Result<T, Box<dyn Error + Send + Sync>>;
 
 #[derive(Debug)]
 pub struct Property {
@@ -43,17 +40,14 @@ impl Property {
             crate::models::ValueKind::Numeric => {
                 Value::Numeric(NumericValue(model_value.0.clone()))
             }
-            crate::models::ValueKind::Boolean => Value::Boolean(
-                model_value
-                    .0
-                    .as_bool()
-                    .ok_or(AppConfigurationClientError::ProtocolError)?,
-            ),
+            crate::models::ValueKind::Boolean => {
+                Value::Boolean(model_value.0.as_bool().ok_or(Error::ProtocolError)?)
+            }
             crate::models::ValueKind::String => Value::String(
                 model_value
                     .0
                     .as_str()
-                    .ok_or(AppConfigurationClientError::ProtocolError)?
+                    .ok_or(Error::ProtocolError)?
                     .to_string(),
             ),
         };

--- a/src/client/property_proxy.rs
+++ b/src/client/property_proxy.rs
@@ -21,7 +21,7 @@ use crate::{
 
 use crate::entity::Entity;
 
-use super::cache::ConfigurationAccessError;
+use crate::errors::ConfigurationAccessError;
 
 const MISSING_PROPERTY_ERROR_MSG: &str = "The property should exist in the index. It should have been validated in `AppConfigurationClient::get_property()`.";
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,93 @@
+use std::sync::PoisonError;
+
+use thiserror::Error;
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("Cannot acquire snapshot lock")]
+    CannotAcquireLock,
+
+    #[error("Feature '{feature_id}' does not exist in environment '{environment_id}' and collection '{collection_id}'")]
+    FeatureDoesNotExist {
+        collection_id: String,
+        environment_id: String,
+        feature_id: String,
+    },
+
+    #[error("Property '{property_id}' does not exist in environment '{environment_id}' and collection '{collection_id}'")]
+    PropertyDoesNotExist {
+        collection_id: String,
+        environment_id: String,
+        property_id: String,
+    },
+
+    #[error(transparent)]
+    ReqwestError(#[from] reqwest::Error),
+
+    #[error(transparent)]
+    TungsteniteError(#[from] tungstenite::Error),
+
+    #[error("Protocol error. Unexpected data received from server")]
+    ProtocolError,
+
+    #[error(transparent)]
+    DeserializationError(#[from] DeserializationError),
+
+    #[error("Client is not configured")]
+    ClientNotConfigured,
+
+    #[error(transparent)]
+    ConfigurationAccessError(#[from] ConfigurationAccessError),
+
+    #[error("{0}")]
+    Other(String),
+}
+
+impl<T> From<PoisonError<T>> for Error {
+    fn from(_value: PoisonError<T>) -> Self {
+        Error::CannotAcquireLock
+    }
+}
+
+/// An error that can be returned when deserializing data.
+#[derive(Debug, Error)]
+#[error("Cannot deserialize string '{string}': {source}")]
+pub struct DeserializationError {
+    pub string: String,
+    pub source: DeserializationErrorKind,
+}
+
+/// Additional information for [`DeserializationError`] error
+#[derive(Debug, Error)]
+pub enum DeserializationErrorKind {
+    #[error(transparent)]
+    SerdeError(#[from] serde_json::Error),
+}
+
+#[derive(Debug, Error)]
+pub enum ConfigurationAccessError {
+    #[error("Error acquiring index cache lock")]
+    LockAcquisitionError,
+
+    #[error(
+        "Environment '{environment_id}' indicated as key not found in the configuration instance"
+    )]
+    EnvironmentNotFound { environment_id: String },
+
+    #[error("Feature `{feature_id}` not found.")]
+    FeatureNotFound { feature_id: String },
+
+    #[error("Property `{property_id}` not found.")]
+    PropertyNotFound { property_id: String },
+
+    #[error("Missing segments for resource '{resource_id}'")]
+    MissingSegments { resource_id: String },
+}
+
+impl<T> From<PoisonError<T>> for ConfigurationAccessError {
+    fn from(_value: PoisonError<T>) -> Self {
+        ConfigurationAccessError::LockAcquisitionError
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ pub mod client;
 pub mod entity;
 pub mod models;
 mod segment_evaluation;
+pub mod errors;
 
 pub use entity::{AttrValue, Entity};
 


### PR DESCRIPTION
#5

 * Move all error declarations to `error.rs`
 * Make them derive from the `thiserror::Error` and implement its useful macros
 * Substitute previous error types by these ones