### PR TITLE
Improve error handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ tungstenite = { version = "0.24.0", features = ["native-tls"] }
 url = "2.5.2"
 http = "1.1.0"
 thiserror = "2.0.4"
+anyhow = "1.0.94"
 
 [dev-dependencies]
 dotenvy = "0.15.7"

--- a/src/client/feature.rs
+++ b/src/client/feature.rs
@@ -43,13 +43,13 @@ impl Feature {
                 Value::Numeric(NumericValue(model_value.0.clone()))
             }
             crate::models::ValueKind::Boolean => {
-                Value::Boolean(model_value.0.as_bool().ok_or(Error::ProtocolError)?)
+                Value::Boolean(model_value.0.as_bool().ok_or(Error::ProtocolError("Expected Boolean".into()))?)
             }
             crate::models::ValueKind::String => Value::String(
                 model_value
                     .0
                     .as_str()
-                    .ok_or(Error::ProtocolError)?
+                    .ok_or(Error::ProtocolError("Expected String".into()))?
                     .to_string(),
             ),
         };
@@ -73,7 +73,7 @@ impl Feature {
             &self.segments,
             self.feature.segment_rules.clone().into_iter(),
             entity,
-        ) {
+        )? {
             Some(segment_rule) => {
                 // Get rollout percentage
                 let rollout_percentage = match segment_rule.rollout_percentage {

--- a/src/client/feature_proxy.rs
+++ b/src/client/feature_proxy.rs
@@ -171,7 +171,7 @@ impl FeatureProxy {
                 .segments,
             self.get_targeting_rules().into_iter(),
             entity,
-        );
+        ).unwrap_or_else(|e| panic!("Failed to evaluate segment rules: {e}"));
         if let Some(segment_rule) = segment_rule {
             let rollout_percentage = self.resolve_rollout_percentage(&segment_rule);
             if rollout_percentage == 100 || random_value(&tag) < rollout_percentage {

--- a/src/client/property.rs
+++ b/src/client/property.rs
@@ -41,13 +41,13 @@ impl Property {
                 Value::Numeric(NumericValue(model_value.0.clone()))
             }
             crate::models::ValueKind::Boolean => {
-                Value::Boolean(model_value.0.as_bool().ok_or(Error::ProtocolError)?)
+                Value::Boolean(model_value.0.as_bool().ok_or(Error::ProtocolError("Expected Boolean".into()))?)
             }
             crate::models::ValueKind::String => Value::String(
                 model_value
                     .0
                     .as_str()
-                    .ok_or(Error::ProtocolError)?
+                    .ok_or(Error::ProtocolError("Expected String".into()))?
                     .to_string(),
             ),
         };
@@ -69,7 +69,7 @@ impl Property {
             &self.segments,
             self.property.segment_rules.clone().into_iter(),
             entity,
-        ) {
+        )? {
             Some(segment_rule) => {
                 if segment_rule.value.is_default() {
                     Ok(self.property.value.clone())

--- a/src/client/property_proxy.rs
+++ b/src/client/property_proxy.rs
@@ -126,7 +126,7 @@ impl PropertyProxy {
                 .segments,
             self.get_targeting_rules().into_iter(),
             entity,
-        );
+        ).unwrap_or_else(|e| panic!("Failed to evaluate segment rules: {e}"));
         if let Some(segment_rule) = segment_rule {
             self.resolve_value(&segment_rule)
         } else {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -30,7 +30,7 @@ pub enum Error {
     TungsteniteError(#[from] tungstenite::Error),
 
     #[error("Protocol error. Unexpected data received from server")]
-    ProtocolError,
+    ProtocolError(String),
 
     #[error(transparent)]
     DeserializationError(#[from] DeserializationError),
@@ -40,6 +40,9 @@ pub enum Error {
 
     #[error(transparent)]
     ConfigurationAccessError(#[from] ConfigurationAccessError),
+
+    #[error("Failed to evaluate entity: {0}")]
+    EntityEvaluationError(String),
 
     #[error("{0}")]
     Other(String),

--- a/src/segment_evaluation.rs
+++ b/src/segment_evaluation.rs
@@ -19,125 +19,156 @@ use crate::{
     entity::{AttrValue, Entity},
     models::TargetingRule,
 };
+use crate::errors::{Result, Error};
+
+// For chaining errors creating useful error messages:
+use anyhow::{Context, Result as AnyhowResult};
+use anyhow::anyhow;
 
 pub(crate) fn find_applicable_segment_rule_for_entity(
     segments: &HashMap<String, Segment>,
     segment_rules: impl Iterator<Item = TargetingRule>,
     entity: &impl Entity,
-) -> Option<TargetingRule> {
+) -> Result<Option<TargetingRule>> {
     let mut targeting_rules = segment_rules.collect::<Vec<_>>();
     targeting_rules.sort_by(|a, b| a.order.cmp(&b.order));
-    targeting_rules
-        .into_iter()
-        .find(|targeting_rule| targeting_rule_applies_to_entity(segments, targeting_rule, entity))
+
+    for targeting_rule in targeting_rules.into_iter(){
+        if targeting_rule_applies_to_entity(segments, &targeting_rule, entity)
+        .map_err(
+            |e|{
+            // This terminates the use of anyhow in this module, converting all errors:
+            let cause: String = e.chain().map(|c| format!("\nCaused by: {c}")).collect();
+            Error::EntityEvaluationError(format!("Failed to evaluate entity '{}' against targeting rule '{}'.{cause}", entity.get_id(), targeting_rule.order))
+        })?
+        {
+            return Ok(Some(targeting_rule));
+        }
+    }
+    return Ok(None)
 }
 
 fn targeting_rule_applies_to_entity(
     segments: &HashMap<String, Segment>,
     targeting_rule: &TargetingRule,
     entity: &impl Entity,
-) -> bool {
+) -> AnyhowResult<bool> {
+    // TODO: we need to get the naming correct here to distinguish between rules, segments, segment_ids, targeting_rules etc. correctly
     let rules = &targeting_rule.rules;
-    rules
-        .iter()
-        .any(|rules| segment_applies_to_entity(segments, &rules.segments, entity))
+    for rule in rules.iter(){
+        let rule_applies = segment_applies_to_entity(segments, &rule.segments, entity)?;
+        if rule_applies {return Ok(true)}
+    }
+    Ok(false)
 }
 
 fn segment_applies_to_entity(
     segments: &HashMap<String, Segment>,
     segment_ids: &[String],
     entity: &impl Entity,
-) -> bool {
-    segment_ids
-        .iter()
-        .map(|segment_id| {
-            segments
-                .get(segment_id)
-                .unwrap_or_else(|| panic!("Segment {} not found", segment_id))
-        })
-        .any(|segment| belong_to_segment(segment, entity.get_attributes()))
+) -> AnyhowResult<bool> {
+    for segment_id in segment_ids.iter(){
+        let segment = segments.get(segment_id)
+            .ok_or(Error::Other(format!("Segment '{segment_id}' not found.").into()))?;
+        let applies = belong_to_segment(segment, entity.get_attributes()).context(format!("Failed to evaluate segment '{segment_id}'"))?;
+        if applies {return Ok(true)}
+    }
+    Ok(false)
 }
 
-fn belong_to_segment(segment: &Segment, attrs: HashMap<String, AttrValue>) -> bool {
-    segment.rules.iter().all(|rule| {
+fn belong_to_segment(segment: &Segment, attrs: HashMap<String, AttrValue>) -> AnyhowResult<bool> {
+    for rule in segment.rules.iter() {
         let operator = &rule.operator;
         let attr_name = &rule.attribute_name;
         let attr_value = attrs
             .get(attr_name)
-            .expect("Attribute does not exist in the entity.");
-        rule.values
-            .iter()
-            .any(|value| check_operator(attr_value, operator, value))
-    })
+            .ok_or(Error::Other(format!("Operation '{attr_name}' '{operator}' '[...]' failed to evaluate: '{attr_name}' not found in entity")))?;
+        for value in rule.values.iter()
+        {
+            let result = check_operator(attr_value, operator, value).context(format!("Operation '{attr_name}' '{operator}' '{value}' failed to evaluate."))?;
+            if result {return Ok(true)}
+        }
+        return Ok(false);
+    }
+    Ok(true)
 }
 
-fn check_operator(attribute_value: &AttrValue, operator: &str, reference_value: &str) -> bool {
+fn check_operator(attribute_value: &AttrValue, operator: &str, reference_value: &str) -> AnyhowResult<bool> {
     match operator {
         "is" => match attribute_value {
-            AttrValue::String(data) => *data == reference_value,
+            AttrValue::String(data) => Ok(*data == reference_value),
             AttrValue::Boolean(data) => {
-                *data
+                let result = *data
                     == reference_value
-                        .parse::<bool>()
-                        .expect("Value cannot convert into a bool.")
+                        .parse::<bool>().map_err(|_| anyhow!("Entity attribute has unexpected type: Boolean."))?;
+                Ok(result)
             }
             AttrValue::Numeric(data) => {
-                *data
+                let result = *data
                     == reference_value
-                        .parse::<f64>()
-                        .expect("Value cannot convert into a number.")
+                        .parse::<f64>().map_err(|_| anyhow!("Entity attribute has unexpected type: Number."))?;
+                    Ok(result)
             }
         },
         "contains" => match attribute_value {
-            AttrValue::String(data) => data.contains(reference_value),
-            _ => panic!("Entity attribute is not a string."),
+            AttrValue::String(data) => Ok(data.contains(reference_value)),
+            _ => Err(anyhow!("Entity attribute is not a string.")),
         },
         "startsWith" => match attribute_value {
-            AttrValue::String(data) => data.starts_with(reference_value),
-            _ => panic!("Entity attribute is not a string."),
+            AttrValue::String(data) => Ok(data.starts_with(reference_value)),
+            _ => Err(anyhow!("Entity attribute is not a string.")),
         },
         "endsWith" => match attribute_value {
-            AttrValue::String(data) => data.ends_with(reference_value),
-            _ => panic!("Entity attribute is not a string."),
+            AttrValue::String(data) => Ok(data.ends_with(reference_value)),
+            _ => Err(anyhow!("Entity attribute is not a string.")),
         },
         "greaterThan" => match attribute_value {
+            // TODO: Go implementation also compares strings (by parsing them as floats). Do we need this?
+            //       https://github.com/IBM/appconfiguration-go-sdk/blob/master/lib/internal/models/Rule.go#L82
+            // TODO: we could have numbers not representable as f64, maybe we should try to parse it to i64 and u64 too?
+            // TODO: we should have a different nesting style here: match the reference_value first and error out when given
+            //       entity attr does not match. This would yield more natural error messages
             AttrValue::Numeric(data) => {
-                *data
+                let result = *data
                     > reference_value
                         .parse()
-                        .expect("Value cannot be converted to number.")
+                        .map_err(|_| Error::Other("Value cannot convert into f64.".into()))?;
+                Ok(result)
             }
-            _ => panic!("Entity attribute is not a number."),
+            _ => Err(anyhow!("Entity attribute is not a number.")),
         },
         "lesserThan" => match attribute_value {
             AttrValue::Numeric(data) => {
-                *data
+                let result = *data
                     < reference_value
                         .parse()
-                        .expect("Value cannot be converted to number.")
+                        .map_err(|_| Error::Other("Value cannot convert into f64.".into()))?;
+                Ok(result)
             }
-            _ => panic!("Entity attribute is not a number."),
+            _ => Err(anyhow!("Entity attribute is not a number.")),
         },
         "greaterThanEquals" => match attribute_value {
             AttrValue::Numeric(data) => {
-                *data
+                let result = *data
                     >= reference_value
                         .parse()
-                        .expect("Value cannot be converted to number.")
+                        .map_err(|_| Error::Other("Value cannot convert into f64.".into()))?;
+                Ok(result)
             }
-            _ => panic!("Entity attribute is not a number."),
+            _ => Err(anyhow!("Entity attribute is not a number.")),
         },
         "lesserThanEquals" => match attribute_value {
             AttrValue::Numeric(data) => {
-                *data
+                let result = *data
                     <= reference_value
                         .parse()
-                        .expect("Value cannot be converted to number.")
+                        .map_err(|_| Error::Other("Value cannot convert into f64.".into()))?;
+                Ok(result)
             }
-            _ => panic!("Entity attribute is not a number."),
+            _ => Err(anyhow!("Entity attribute is not a number.")),
         },
-        v => {
-            panic!("{} not implemented yet", v);
+        _ => {
+            Err(anyhow!("Operator not implemented"))
         }
     }
 }
@@ -149,11 +180,11 @@ pub mod tests {
         models::{ConfigValue, Segment, SegmentRule, Segments, TargetingRule},
         AttrValue,
     };
+    use rstest::*;
 
-    #[ignore] // This fails, probably a bug. Need to cross check expectation with go impl.
-    #[test]
-    fn test_missing_attribute() {
-        let segments = HashMap::from([(
+    #[fixture]
+    fn segments() -> HashMap<String, Segment> {
+        HashMap::from([(
             "some_segment_id_1".into(),
             Segment {
                 name: "".into(),
@@ -166,21 +197,61 @@ pub mod tests {
                     values: vec!["heinz".into()],
                 }],
             },
-        )]);
-        let segment_rules = vec![TargetingRule {
+        )])
+    }
+
+    #[fixture]
+    fn segment_rules() -> Vec<TargetingRule>{
+        vec![TargetingRule {
             rules: vec![Segments {
                 segments: vec!["some_segment_id_1".into()],
             }],
             value: ConfigValue(serde_json::Value::Number((-48).into())),
             order: 0,
             rollout_percentage: Some(ConfigValue(serde_json::Value::Number((100).into()))),
-        }];
+        }]
+    }
+
+    #[rstest]
+    fn test_attribute_not_found(segments: HashMap<String, Segment>, segment_rules: Vec<TargetingRule>) {
         let entity = crate::tests::GenericEntity {
             id: "a2".into(),
             attributes: HashMap::from([("name2".into(), AttrValue::from("heinz".to_string()))]),
         };
         let rule =
+            find_applicable_segment_rule_for_entity(&segments, segment_rules.clone().into_iter(), &entity);
+        // Error message should look something like this:
+        //  Failed to evaluate entity 'a2' against targeting rule '0'.
+        //  Caused by: Failed to evaluate segment 'some_segment_id_1'
+        //  Caused by: Operation 'name' 'is' '[...]' failed to evaluate: 'name' not found in entity
+        // We are checking here that the parts are present to allow debugging of config by the user:
+        let msg = rule.unwrap_err().to_string();
+        assert!(msg.contains("'name' not found in entity"));
+        assert!(msg.contains("'a2'"));
+        assert!(msg.contains("'0'"));
+        assert!(msg.contains("'some_segment_id_1'"));
+        assert!(msg.contains("'is'"));
+    }
+
+    #[rstest]
+    fn test_operator_failed(segments: HashMap<String, Segment>, segment_rules: Vec<TargetingRule>) {
+        let entity = crate::tests::GenericEntity {
+            id: "a2".into(),
+            attributes: HashMap::from([("name".into(), AttrValue::from(42.0))]),
+        };
+        let rule =
             find_applicable_segment_rule_for_entity(&segments, segment_rules.into_iter(), &entity);
-        assert!(rule.is_none());
+        // Error message should look something like this:
+        //  Failed to evaluate entity: Failed to evaluate entity 'a2' against targeting rule '0'.
+        //  Caused by: Failed to evaluate segment 'some_segment_id_1'
+        //  Caused by: Operation 'name' 'is' 'heinz' failed to evaluate.
+        //  Caused by: Entity attribute has unexpected type: Number.
+        // We are checking here that the parts are present to allow debugging of config by the user:
+        let msg = rule.unwrap_err().to_string();
+        assert!(msg.contains("'a2'"));
+        assert!(msg.contains("'0'"));
+        assert!(msg.contains("'some_segment_id_1'"));
+        assert!(msg.contains("'name' 'is' 'heinz'"));
+        assert!(msg.contains("Entity attribute has unexpected type: Number"));
     }
 }


### PR DESCRIPTION
- remove some `unwrap`, `panic` and `expect` uses
- Improve error messages
- rework segment evaluation to return errors instead of panic
- Add/rework testcases for some error scenarios

I experimented using `anyhow` to create error chains providing the user with more readable error messages.
For now I terminate `anyhow` usage in segment evaluation code and use the `thiserror` types for everything user-facing.
Feedback appreciated.

The behavior differs from the go implementation in strictness. I'd appreciate Input from @saikumar1607 on what is the intended behavior for error handling in entity evaluation. Is it fine to have the strict enforcement as implemented here?