### PR TITLE
[refactor] Add trait `Resource`: dedup Feature and Property

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 mod app_configuration_client;
+mod resource;
 
 pub(crate) mod cache;
 pub mod feature;
@@ -23,5 +24,5 @@ pub(crate) mod property_proxy;
 pub mod value;
 
 pub use app_configuration_client::AppConfigurationClient;
-
+pub use resource::Resource;
 pub const REGION_US_SOUTH: &str = "us-south";

--- a/src/client/property.rs
+++ b/src/client/property.rs
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::client::value::{NumericValue, Value};
 use crate::entity::Entity;
 use std::collections::HashMap;
 
-use crate::errors::{Error, Result};
+use crate::errors::Result;
 use crate::segment_evaluation::find_applicable_segment_rule_for_entity;
+use super::Resource;
 
 #[derive(Debug)]
 pub struct Property {
@@ -32,26 +32,11 @@ impl Property {
     ) -> Self {
         Self { property, segments }
     }
+}
 
-    pub fn get_value(&self, entity: &impl Entity) -> Result<Value> {
-        let model_value = self.evaluate_feature_for_entity(entity)?;
-
-        let value = match self.property.kind {
-            crate::models::ValueKind::Numeric => {
-                Value::Numeric(NumericValue(model_value.0.clone()))
-            }
-            crate::models::ValueKind::Boolean => {
-                Value::Boolean(model_value.0.as_bool().ok_or(Error::ProtocolError)?)
-            }
-            crate::models::ValueKind::String => Value::String(
-                model_value
-                    .0
-                    .as_str()
-                    .ok_or(Error::ProtocolError)?
-                    .to_string(),
-            ),
-        };
-        Ok(value)
+impl Resource for Property {
+    fn value_type(&self) -> &crate::models::ValueKind {
+        &self.property.kind
     }
 
     fn evaluate_feature_for_entity(
@@ -89,6 +74,7 @@ pub mod tests {
         models::{ConfigValue, Segment, SegmentRule, Segments, TargetingRule, ValueKind},
         AttrValue,
     };
+    use crate::client::value::Value;
 
     #[test]
     fn test_get_value_segment_with_default_value() {

--- a/src/client/resource.rs
+++ b/src/client/resource.rs
@@ -1,3 +1,17 @@
+// (C) Copyright IBM Corp. 2024.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use crate::client::value::{NumericValue, Value};
 use crate::errors::{Error, Result};
 use crate::models::ValueKind;

--- a/src/client/resource.rs
+++ b/src/client/resource.rs
@@ -1,0 +1,34 @@
+use crate::client::value::{NumericValue, Value};
+use crate::errors::{Error, Result};
+use crate::models::ValueKind;
+use crate::Entity;
+
+pub trait Resource {
+    fn get_value(&self, entity: &impl Entity) -> Result<Value> {
+        let model_value = self.evaluate_feature_for_entity(entity)?;
+
+        let value = match self.value_type() {
+            crate::models::ValueKind::Numeric => {
+                Value::Numeric(NumericValue(model_value.0.clone()))
+            }
+            crate::models::ValueKind::Boolean => {
+                Value::Boolean(model_value.0.as_bool().ok_or(Error::ProtocolError)?)
+            }
+            crate::models::ValueKind::String => Value::String(
+                model_value
+                    .0
+                    .as_str()
+                    .ok_or(Error::ProtocolError)?
+                    .to_string(),
+            ),
+        };
+        Ok(value)
+    }
+
+    fn value_type(&self) -> &ValueKind;
+
+    fn evaluate_feature_for_entity(
+        &self,
+        entity: &impl Entity,
+    ) -> Result<crate::models::ConfigValue>;
+}

--- a/src/tests/test_get_feature.rs
+++ b/src/tests/test_get_feature.rs
@@ -15,7 +15,7 @@
 use crate::models::Configuration;
 
 use crate::client::cache::ConfigurationSnapshot;
-use crate::client::AppConfigurationClient;
+use crate::client::{AppConfigurationClient, Resource};
 use rstest::*;
 
 use super::client_enterprise;

--- a/src/tests/test_get_property.rs
+++ b/src/tests/test_get_property.rs
@@ -15,7 +15,7 @@
 use crate::models::Configuration;
 
 use crate::client::cache::ConfigurationSnapshot;
-use crate::client::AppConfigurationClient;
+use crate::client::{AppConfigurationClient, Resource};
 use rstest::*;
 
 use super::client_enterprise;


### PR DESCRIPTION
Initial `Resource` trait that provides `get_value` and `evaluate_feature_for_entity`.

Note.- Only `get_value` should be made public to users, but that requires the public/private trait hack, if we really want to, we can implement it later as part of #7  