### PR TITLE
Implement builder pattern for `AppConfigurationClient`

### DIFF
--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -15,7 +15,7 @@
 use std::{collections::HashMap, env, thread, time::Duration};
 
 use appconfiguration_rust_sdk::{
-    AppConfigurationClient, AttrValue, Entity, Feature, Property, Value,
+    AppConfigClientBuilder, AppConfigIBMCloudBuilder, AttrValue, Entity, Feature, Property, Value,
 };
 use dotenvy::dotenv;
 use std::error::Error;
@@ -42,16 +42,17 @@ impl Entity for CustomerEntity {
 
 fn main() -> std::result::Result<(), Box<dyn Error>> {
     dotenv().ok();
-    let region = env::var("REGION").expect("REGION should be set.");
-    let guid = env::var("GUID").expect("GUID should be set.");
-    let apikey = env::var("APIKEY").expect("APIKEY should be set.");
-    let collection_id = env::var("COLLECTION_ID").expect("COLLECTION_ID should be set.");
-    let environment_id = env::var("ENVIRONMENT_ID").expect("ENVIRONMENT_ID should be set.");
-    let feature_id = env::var("FEATURE_ID").expect("FEATURE_ID should be set.");
-    let property_id = env::var("PROPERTY_ID").expect("PROPERTY_ID should be set.");
+    let region = env::var("REGION").or(Err("'REGION' envvar is required."))?;
+    let guid = env::var("GUID").or(Err("'GUID' envvar should be set."))?;
+    let apikey = env::var("APIKEY").or(Err("'APIKEY' envvar should be set."))?;
+    let collection_id = env::var("COLLECTION_ID").or(Err("'COLLECTION_ID' envvar should be set."))?;
+    let environment_id = env::var("ENVIRONMENT_ID").or(Err("'ENVIRONMENT_ID' envvar should be set."))?;
+    let feature_id = env::var("FEATURE_ID").or(Err("'FEATURE_ID' envvar should be set."))?;
+    let property_id = env::var("PROPERTY_ID").or(Err("'PROPERTY_ID' envvar should be set."))?;
 
     let client =
-        AppConfigurationClient::new(&apikey, &region, &guid, &environment_id, &collection_id)?;
+        AppConfigIBMCloudBuilder::new(&region, &apikey, &guid, &environment_id, &collection_id)
+            .build()?;
 
     let entity = CustomerEntity {
         id: "user123".to_string(),

--- a/src/builders/mod.rs
+++ b/src/builders/mod.rs
@@ -1,0 +1,70 @@
+// (C) Copyright IBM Corp. 2024.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::AppConfigurationClient;
+use crate::Result;
+
+pub trait AppConfigClientBuilder {
+    /// Creates and returns the [`AppConfigurationClient`]
+    fn build(self) -> Result<AppConfigurationClient>;
+}
+
+/// An [`AppConfigurationClient`] builder to create a client connecting to IBM Cloud
+pub struct AppConfigIBMCloudBuilder<'a> {
+    region: &'a str,
+    apikey: &'a str,
+    guid: &'a str,
+    environment_id: &'a str,
+    collection_id: &'a str,
+}
+
+impl<'a> AppConfigIBMCloudBuilder<'a> {
+    /// Creates a builder with the data required to instantiate a new [`AppConfigClientBuilder`]
+    /// connecting to IBM Cloud
+    ///
+    /// # Arguments
+    ///
+    /// * `region` - Region name where the App Configuration service instance is created
+    /// * `apikey` - The encrypted API key.
+    /// * `guid` - Instance ID of the App Configuration service. Obtain it from the service credentials section of the App Configuration dashboard
+    /// * `collection_id` - ID of the collection created in App Configuration service instance under the Collections section
+    /// * `environment_id` - ID of the environment created in App Configuration service instance under the Environments section.
+    pub fn new(
+        region: &'a str,
+        apikey: &'a str,
+        guid: &'a str,
+        environment_id: &'a str,
+        collection_id: &'a str,
+    ) -> Self {
+        Self {
+            region,
+            apikey,
+            guid,
+            environment_id,
+            collection_id,
+        }
+    }
+}
+
+impl<'a> AppConfigClientBuilder for AppConfigIBMCloudBuilder<'a> {
+    fn build(self) -> Result<AppConfigurationClient> {
+        AppConfigurationClient::new(
+            self.apikey,
+            self.region,
+            self.guid,
+            self.environment_id,
+            self.collection_id,
+        )
+    }
+}

--- a/src/client/app_configuration_client.rs
+++ b/src/client/app_configuration_client.rs
@@ -38,14 +38,7 @@ pub struct AppConfigurationClient {
 }
 
 impl AppConfigurationClient {
-    /// Creates a client to retrieve configurations for a specific collection.
-    /// To uniquely address a collection the following is required:
-    /// - `region`
-    /// - `guid`: Identifies an instance
-    /// - `environment_id`
-    /// - `collection_id`
-    /// In addition `api_key` is required for authentication
-    pub fn new(
+    pub(crate) fn new(
         apikey: &str,
         region: &str,
         guid: &str,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod builders;
 mod client;
 mod entity;
 mod errors;
@@ -21,12 +22,13 @@ mod property;
 mod segment_evaluation;
 mod value;
 
+pub use builders::{AppConfigClientBuilder, AppConfigIBMCloudBuilder};
 pub use client::AppConfigurationClient;
-pub use entity::{Entity, AttrValue};
+pub use entity::{AttrValue, Entity};
+pub use errors::{Error, Result};
 pub use feature::Feature;
 pub use property::Property;
 pub use value::Value;
-pub use errors::{Result, Error};
 
 #[cfg(test)]
 mod tests;

--- a/tests/test_app_config.rs
+++ b/tests/test_app_config.rs
@@ -16,7 +16,8 @@ use dotenvy::dotenv;
 use rstest::*;
 
 use appconfiguration_rust_sdk::{
-    AppConfigurationClient, AttrValue, Entity, Feature, Property, Value,
+    AppConfigClientBuilder, AppConfigIBMCloudBuilder, AppConfigurationClient, AttrValue, Entity,
+    Feature, Property, Value,
 };
 use std::collections::HashMap;
 use std::env;
@@ -44,7 +45,9 @@ fn setup_client() -> AppConfigurationClient {
 
     //TODO: Our current pricing plan doesn't allow more than 1 collection, so we are using
     // car-rentals so far.
-    AppConfigurationClient::new(&apikey, &region, &guid, "testing", "car-rentals").unwrap()
+    AppConfigIBMCloudBuilder::new(&region, &apikey, &guid, "testing", "car-rentals")
+        .build()
+        .unwrap()
 }
 
 #[rstest]


### PR DESCRIPTION
closes #31

Now that I've written this, I wonder if it would be easier to have a `AppConfigurationClient` trait and multiple implementations:

```rust
AppConfigurationIBMCloud::new(region, api_key);

AppConfigurationLocal::new(filepath);

AppConfigurationURLServer::new(url);
```