### PR TITLE
Remove `AttrValue`, we only have `Value` (with more explicit types)

### DIFF
--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -14,9 +14,7 @@
 
 use std::{collections::HashMap, env, thread, time::Duration};
 
-use appconfiguration_rust_sdk::{
-    AppConfigurationClient, AttrValue, Entity, Feature, Property, Value,
-};
+use appconfiguration_rust_sdk::{AppConfigurationClient, Entity, Feature, Property, Value};
 use dotenvy::dotenv;
 use std::error::Error;
 
@@ -32,10 +30,10 @@ impl Entity for CustomerEntity {
         self.id.clone()
     }
 
-    fn get_attributes(&self) -> HashMap<String, AttrValue> {
+    fn get_attributes(&self) -> HashMap<String, Value> {
         HashMap::from_iter(vec![
-            ("city".to_string(), AttrValue::String(self.city.clone())),
-            ("radius".to_string(), AttrValue::Numeric(self.radius as f64)),
+            ("city".to_string(), Value::from(self.city.clone())),
+            ("radius".to_string(), Value::from(self.radius as u64)),
         ])
     }
 }
@@ -69,12 +67,6 @@ fn main() -> std::result::Result<(), Box<dyn Error>> {
             Ok(feature) => {
                 println!("Feature name: {}", feature.get_name()?);
                 let value = feature.get_value(&entity)?;
-                let data_type = match &value {
-                    Value::Numeric(_) => "Numeric",
-                    Value::String(_) => "String",
-                    Value::Boolean(_) => "Boolean",
-                };
-                println!("Feature data type: {}", data_type);
                 println!("Is feature enabled: {}", feature.is_enabled()?);
                 println!("Feature evaluated value is: {value:?}");
             }
@@ -88,12 +80,6 @@ fn main() -> std::result::Result<(), Box<dyn Error>> {
             Ok(property) => {
                 println!("Property name: {}", property.get_name()?);
                 let value = property.get_value(&entity)?;
-                let data_type = match &value {
-                    Value::Numeric(_) => "Numeric",
-                    Value::String(_) => "String",
-                    Value::Boolean(_) => "Boolean",
-                };
-                println!("Property data type: {data_type}");
                 println!("Property evaluated value is: {value:?}");
             }
             Err(error) => {

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -14,6 +14,9 @@
 
 use std::collections::HashMap;
 
+use crate::Value;
+
+
 /// An object on which evaluate properties and features.
 pub trait Entity {
     /// Gets a unique identifier for the entity.
@@ -21,34 +24,7 @@ pub trait Entity {
 
     /// Gets a map of attributes names and values against which evaluate the
     /// entities belonging to segments.
-    fn get_attributes(&self) -> HashMap<String, AttrValue> {
+    fn get_attributes(&self) -> HashMap<String, Value> {
         HashMap::new()
-    }
-}
-
-/// An attribute value can be of one of three types: numerics, strings, or
-/// booleans.
-#[derive(Debug, Clone)]
-pub enum AttrValue {
-    Numeric(f64),
-    String(String),
-    Boolean(bool),
-}
-
-impl From<f64> for AttrValue {
-    fn from(value: f64) -> Self {
-        AttrValue::Numeric(value)
-    }
-}
-
-impl From<String> for AttrValue {
-    fn from(value: String) -> Self {
-        AttrValue::String(value)
-    }
-}
-
-impl From<bool> for AttrValue {
-    fn from(value: bool) -> Self {
-        AttrValue::Boolean(value)
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -25,6 +25,9 @@ pub enum Error {
         property_id: String,
     },
 
+    #[error("Inner type cannot be converted to requested type")]
+    MismatchType,
+
     #[error(transparent)]
     ReqwestError(#[from] reqwest::Error),
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,11 +22,11 @@ mod segment_evaluation;
 mod value;
 
 pub use client::AppConfigurationClient;
-pub use entity::{Entity, AttrValue};
+pub use entity::Entity;
+pub use errors::{Error, Result};
 pub use feature::Feature;
 pub use property::Property;
 pub use value::Value;
-pub use errors::{Result, Error};
 
 #[cfg(test)]
 mod tests;

--- a/src/segment_evaluation/errors.rs
+++ b/src/segment_evaluation/errors.rs
@@ -54,8 +54,11 @@ pub(crate) enum CheckOperatorErrorDetail {
     #[error("Entity attribute has unexpected type: Boolean.")]
     BooleanExpected(#[from] std::str::ParseBoolError),
 
-    #[error("Entity attribute has unexpected type: Number.")]
-    NumberExpected(#[from] std::num::ParseFloatError),
+    #[error("Entity attribute has unexpected type: float.")]
+    FloatExpected(#[from] std::num::ParseFloatError),
+
+    #[error("Entity attribute has unexpected type: integer.")]
+    IntegerExpected(#[from] std::num::ParseIntError),
 
     #[error("Entity attribute is not a number.")]
     EntityAttrNotANumber,

--- a/src/segment_evaluation/mod.rs
+++ b/src/segment_evaluation/mod.rs
@@ -16,10 +16,11 @@ pub(crate) mod errors;
 
 use std::collections::HashMap;
 
-use crate::entity::{AttrValue, Entity};
+use crate::entity::{Entity};
 use crate::errors::Result;
 use crate::models::Segment;
 use crate::models::TargetingRule;
+use crate::Value;
 use errors::{CheckOperatorErrorDetail, SegmentEvaluationError};
 
 pub(crate) fn find_applicable_segment_rule_for_entity(
@@ -75,7 +76,7 @@ fn segment_applies_to_entity(
 
 fn belong_to_segment(
     segment: &Segment,
-    attrs: HashMap<String, AttrValue>,
+    attrs: HashMap<String, Value>,
 ) -> std::result::Result<bool, SegmentEvaluationError> {
     for rule in segment.rules.iter() {
         let operator = &rule.operator;
@@ -115,45 +116,55 @@ fn belong_to_segment(
 }
 
 fn check_operator(
-    attribute_value: &AttrValue,
+    attribute_value: &Value,
     operator: &str,
     reference_value: &str,
 ) -> std::result::Result<bool, CheckOperatorErrorDetail> {
     match operator {
         "is" => match attribute_value {
-            AttrValue::String(data) => Ok(*data == reference_value),
-            AttrValue::Boolean(data) => Ok(*data == reference_value.parse::<bool>()?),
-            AttrValue::Numeric(data) => Ok(*data == reference_value.parse::<f64>()?),
+            Value::String(data) => Ok(*data == reference_value),
+            Value::Boolean(data) => Ok(*data == reference_value.parse::<bool>()?),
+            Value::Float64(data) => Ok(*data == reference_value.parse::<f64>()?),
+            Value::UInt64(data) => Ok(*data == reference_value.parse::<u64>()?),
+            Value::Int64(data) => Ok(*data == reference_value.parse::<i64>()?),
         },
         "contains" => match attribute_value {
-            AttrValue::String(data) => Ok(data.contains(reference_value)),
+            Value::String(data) => Ok(data.contains(reference_value)),
             _ => Err(CheckOperatorErrorDetail::StringExpected),
         },
         "startsWith" => match attribute_value {
-            AttrValue::String(data) => Ok(data.starts_with(reference_value)),
+            Value::String(data) => Ok(data.starts_with(reference_value)),
             _ => Err(CheckOperatorErrorDetail::StringExpected),
         },
         "endsWith" => match attribute_value {
-            AttrValue::String(data) => Ok(data.ends_with(reference_value)),
+            Value::String(data) => Ok(data.ends_with(reference_value)),
             _ => Err(CheckOperatorErrorDetail::StringExpected),
         },
         "greaterThan" => match attribute_value {
             // TODO: Go implementation also compares strings (by parsing them as floats). Do we need this?
             //       https://github.com/IBM/appconfiguration-go-sdk/blob/master/lib/internal/models/Rule.go#L82
             // TODO: we could have numbers not representable as f64, maybe we should try to parse it to i64 and u64 too?
-            AttrValue::Numeric(data) => Ok(*data > reference_value.parse()?),
+            Value::Float64(data) => Ok(*data > reference_value.parse()?),
+            Value::UInt64(data) => Ok(*data > reference_value.parse()?),
+            Value::Int64(data) => Ok(*data > reference_value.parse()?),
             _ => Err(CheckOperatorErrorDetail::EntityAttrNotANumber),
         },
         "lesserThan" => match attribute_value {
-            AttrValue::Numeric(data) => Ok(*data < reference_value.parse()?),
+            Value::Float64(data) => Ok(*data < reference_value.parse()?),
+            Value::UInt64(data) => Ok(*data < reference_value.parse()?),
+            Value::Int64(data) => Ok(*data < reference_value.parse()?),
             _ => Err(CheckOperatorErrorDetail::EntityAttrNotANumber),
         },
         "greaterThanEquals" => match attribute_value {
-            AttrValue::Numeric(data) => Ok(*data >= reference_value.parse()?),
+            Value::Float64(data) => Ok(*data >= reference_value.parse()?),
+            Value::UInt64(data) => Ok(*data >= reference_value.parse()?),
+            Value::Int64(data) => Ok(*data >= reference_value.parse()?),
             _ => Err(CheckOperatorErrorDetail::EntityAttrNotANumber),
         },
         "lesserThanEquals" => match attribute_value {
-            AttrValue::Numeric(data) => Ok(*data <= reference_value.parse()?),
+            Value::Float64(data) => Ok(*data <= reference_value.parse()?),
+            Value::UInt64(data) => Ok(*data <= reference_value.parse()?),
+            Value::Int64(data) => Ok(*data <= reference_value.parse()?),
             _ => Err(CheckOperatorErrorDetail::EntityAttrNotANumber),
         },
         _ => Err(CheckOperatorErrorDetail::OperatorNotImplemented),
@@ -207,7 +218,7 @@ pub mod tests {
     ) {
         let entity = crate::tests::GenericEntity {
             id: "a2".into(),
-            attributes: HashMap::from([("name2".into(), AttrValue::from("heinz".to_string()))]),
+            attributes: HashMap::from([("name2".into(), Value::from("heinz".to_string()))]),
         };
         let rule =
             find_applicable_segment_rule_for_entity(&segments, segment_rules.into_iter(), &entity);
@@ -224,7 +235,7 @@ pub mod tests {
     fn test_invalid_segment_id(segments: HashMap<String, Segment>) {
         let entity = crate::tests::GenericEntity {
             id: "a2".into(),
-            attributes: HashMap::from([("name".into(), AttrValue::from(42.0))]),
+            attributes: HashMap::from([("name".into(), Value::from(42.0))]),
         };
         let segment_rules = vec![TargetingRule {
             rules: vec![Segments {
@@ -257,7 +268,7 @@ pub mod tests {
     fn test_operator_failed(segments: HashMap<String, Segment>, segment_rules: Vec<TargetingRule>) {
         let entity = crate::tests::GenericEntity {
             id: "a2".into(),
-            attributes: HashMap::from([("name".into(), AttrValue::from(42.0))]),
+            attributes: HashMap::from([("name".into(), Value::from(42.0))]),
         };
         let rule =
             find_applicable_segment_rule_for_entity(&segments, segment_rules.into_iter(), &entity);

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -22,11 +22,11 @@ mod test_using_example_data;
 
 use crate::client::cache::ConfigurationSnapshot;
 use crate::client::AppConfigurationClient;
-use crate::entity::AttrValue;
 use crate::models::tests::example_configuration_enterprise;
 use crate::models::Configuration;
 use crate::Entity;
 use rstest::fixture;
+use crate::Value;
 use std::sync::{Arc, Mutex};
 
 pub struct TrivialEntity;
@@ -36,14 +36,14 @@ impl Entity for TrivialEntity {
         "TrivialId".into()
     }
 
-    fn get_attributes(&self) -> HashMap<String, AttrValue> {
+    fn get_attributes(&self) -> HashMap<String, Value> {
         HashMap::new()
     }
 }
 
 pub struct GenericEntity {
     pub id: String,
-    pub attributes: HashMap<String, AttrValue>,
+    pub attributes: HashMap<String, Value>,
 }
 
 impl Entity for GenericEntity {
@@ -51,7 +51,7 @@ impl Entity for GenericEntity {
         self.id.clone()
     }
 
-    fn get_attributes(&self) -> HashMap<String, AttrValue> {
+    fn get_attributes(&self) -> HashMap<String, Value> {
         self.attributes.clone()
     }
 }

--- a/src/tests/test_using_example_data.rs
+++ b/src/tests/test_using_example_data.rs
@@ -29,7 +29,7 @@ fn test_get_a_specific_feature(client_enterprise: AppConfigurationClient) {
 
     assert_eq!(name, "F1".to_string());
     assert!(is_enabled);
-    assert!(matches!(value, Value::Numeric(ref v) if v.as_i64() == Some(5)));
+    assert!(matches!(value, Value::Int64(ref v) if v == &5));
 }
 
 #[rstest]
@@ -40,5 +40,5 @@ fn test_get_a_specific_property(client_enterprise: AppConfigurationClient) {
     let value = property.get_value(&TrivialEntity).unwrap();
 
     assert_eq!(name, "p1");
-    assert!(matches!(value, Value::Numeric(ref v) if v.as_i64() == Some(5)));
+    assert!(matches!(value, Value::Int64(ref v) if v == &5));
 }

--- a/src/value.rs
+++ b/src/value.rs
@@ -12,26 +12,102 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[derive(PartialEq, Debug)]
-pub struct NumericValue(pub(crate) serde_json::Value);
+use crate::Error;
 
-impl NumericValue {
-    pub fn as_i64(&self) -> Option<i64> {
-        self.0.as_i64()
-    }
-    pub fn as_u64(&self) -> Option<u64> {
-        self.0.as_u64()
-    }
-    pub fn as_f64(&self) -> Option<f64> {
-        self.0.as_f64()
+#[derive(PartialEq, Debug, Clone)]
+pub enum Value {
+    Float64(f64),
+    UInt64(u64),
+    Int64(i64),
+    String(String),
+    Boolean(bool),
+}
+
+impl From<f64> for Value {
+    fn from(value: f64) -> Self {
+        Value::Float64(value)
     }
 }
 
-#[derive(PartialEq, Debug)]
-pub enum Value {
-    Numeric(NumericValue),
-    String(String),
-    Boolean(bool),
+impl From<u64> for Value {
+    fn from(value: u64) -> Self {
+        Value::UInt64(value)
+    }
+}
+
+impl From<i64> for Value {
+    fn from(value: i64) -> Self {
+        Value::Int64(value)
+    }
+}
+
+impl From<String> for Value {
+    fn from(value: String) -> Self {
+        Value::String(value)
+    }
+}
+
+impl From<bool> for Value {
+    fn from(value: bool) -> Self {
+        Value::Boolean(value)
+    }
+}
+
+impl TryFrom<Value> for f64 {
+    type Error = crate::Error;
+
+    fn try_from(value: Value) -> Result<Self, Self::Error> {
+        match value {
+            Value::Float64(f) => Ok(f),
+            _ => Err(Error::MismatchType),
+        }
+    }
+}
+
+impl TryFrom<Value> for u64 {
+    type Error = crate::Error;
+
+    fn try_from(value: Value) -> Result<Self, Self::Error> {
+        match value {
+            Value::UInt64(f) => Ok(f),
+            Value::Int64(v) => v.try_into().map_err(|_| Error::MismatchType),
+            _ => Err(Error::MismatchType),
+        }
+    }
+}
+
+impl TryFrom<Value> for i64 {
+    type Error = crate::Error;
+
+    fn try_from(value: Value) -> Result<Self, Self::Error> {
+        match value {
+            Value::Int64(f) => Ok(f),
+            Value::UInt64(v) => v.try_into().map_err(|_| Error::MismatchType),
+            _ => Err(Error::MismatchType),
+        }
+    }
+}
+
+impl TryFrom<Value> for String {
+    type Error = crate::Error;
+
+    fn try_from(value: Value) -> Result<Self, Self::Error> {
+        match value {
+            Value::String(f) => Ok(f),
+            _ => Err(Error::MismatchType),
+        }
+    }
+}
+
+impl TryFrom<Value> for bool {
+    type Error = crate::Error;
+
+    fn try_from(value: Value) -> Result<Self, Self::Error> {
+        match value {
+            Value::Boolean(f) => Ok(f),
+            _ => Err(Error::MismatchType),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -40,22 +116,95 @@ pub mod tests {
     use super::*;
 
     #[test]
-    fn test_numeric() {
-        let value = Value::Numeric(NumericValue(serde_json::Value::Number(42.into())));
-        assert!(matches!(value, Value::Numeric(ref v) if v.as_f64().unwrap() == 42f64));
-        assert!(matches!(value, Value::Numeric(ref v) if v.as_i64().unwrap() == 42i64));
-        assert!(matches!(value, Value::Numeric(ref v) if v.as_u64().unwrap() == 42u64));
+    fn test_numeric_f64() {
+        let value = Value::from(42f64);
+        assert!(matches!(value, Value::Float64(ref v) if v == &42f64));
 
-        let json_value = serde_json::Value::from(-42.0f64);
-        let value = Value::Numeric(NumericValue(json_value));
-        assert!(matches!(value, Value::Numeric(ref v) if v.as_f64().unwrap() == -42f64));
-        assert!(matches!(value, Value::Numeric(ref v) if v.as_i64().is_none()));
-        assert!(matches!(value, Value::Numeric(ref v) if v.as_u64().is_none()));
+        let as_f64: f64 = value.clone().try_into().unwrap();
+        assert_eq!(as_f64, 42f64);
 
-        let json_value = serde_json::Value::from(-42i64);
-        let value = Value::Numeric(NumericValue(json_value));
-        assert!(matches!(value, Value::Numeric(ref v) if v.as_f64().unwrap() == -42f64));
-        assert!(matches!(value, Value::Numeric(ref v) if v.as_i64().unwrap() == -42i64));
-        assert!(matches!(value, Value::Numeric(ref v) if v.as_u64().is_none()));
+        assert!(matches!(TryInto::<u64>::try_into(value.clone()).unwrap_err(), Error::MismatchType));
+        assert!(matches!(TryInto::<i64>::try_into(value.clone()).unwrap_err(), Error::MismatchType));
+        assert!(matches!(TryInto::<String>::try_into(value.clone()).unwrap_err(), Error::MismatchType));
+        assert!(matches!(TryInto::<bool>::try_into(value.clone()).unwrap_err(), Error::MismatchType));
+    }
+
+    #[test]
+    fn test_numeric_u64() {
+        // An u64 within the range of i64
+        {
+            let value = Value::from(42u64);
+            assert!(matches!(value, Value::UInt64(ref v) if v == &42u64));
+    
+            let as_u64: u64 = value.clone().try_into().unwrap();
+            assert_eq!(as_u64, 42u64);
+
+            let as_i64: i64 = value.clone().try_into().unwrap();
+            assert_eq!(as_i64, 42i64);
+
+            assert!(matches!(TryInto::<f64>::try_into(value.clone()).unwrap_err(), Error::MismatchType));
+            assert!(matches!(TryInto::<String>::try_into(value.clone()).unwrap_err(), Error::MismatchType));
+            assert!(matches!(TryInto::<bool>::try_into(value.clone()).unwrap_err(), Error::MismatchType));
+        }
+
+        // An u64 outside the range of i64
+        {
+            let value = Value::from(u64::MAX);
+            assert!(matches!(TryInto::<i64>::try_into(value.clone()).unwrap_err(), Error::MismatchType));
+        }
+    }
+
+    #[test]
+    fn test_numeric_i64() {
+        // An i64 within the range of u64
+        {
+            let value = Value::from(42i64);
+            assert!(matches!(value, Value::Int64(ref v) if v == &42i64));
+    
+            let as_i64: i64 = value.clone().try_into().unwrap();
+            assert_eq!(as_i64, 42i64);
+
+            let as_u64: u64 = value.clone().try_into().unwrap();
+            assert_eq!(as_u64, 42u64);
+
+            assert!(matches!(TryInto::<f64>::try_into(value.clone()).unwrap_err(), Error::MismatchType));
+            assert!(matches!(TryInto::<String>::try_into(value.clone()).unwrap_err(), Error::MismatchType));
+            assert!(matches!(TryInto::<bool>::try_into(value.clone()).unwrap_err(), Error::MismatchType));
+        }
+
+        // An i64 outside the range of u64
+        {
+            let value = Value::from(-2i64);
+            assert!(matches!(TryInto::<u64>::try_into(value.clone()).unwrap_err(), Error::MismatchType));
+        }
+    }
+    
+    #[test]
+    fn test_string() {
+        let value = Value::from("value".to_string());
+        assert!(matches!(value, Value::String(ref v) if v == "value"));
+
+        let as_string: String = value.clone().try_into().unwrap();
+        assert_eq!(as_string, "value");
+
+        assert!(matches!(TryInto::<f64>::try_into(value.clone()).unwrap_err(), Error::MismatchType));
+        assert!(matches!(TryInto::<u64>::try_into(value.clone()).unwrap_err(), Error::MismatchType));
+        assert!(matches!(TryInto::<i64>::try_into(value.clone()).unwrap_err(), Error::MismatchType));
+        assert!(matches!(TryInto::<bool>::try_into(value.clone()).unwrap_err(), Error::MismatchType));
+    }
+
+    #[test]
+    #[allow(clippy::bool_assert_comparison)]
+    fn test_boolean() {
+        let value = Value::from(false);
+        assert!(matches!(value, Value::Boolean(ref v) if v == &false));
+
+        let as_boolean: bool = value.clone().try_into().unwrap();
+        assert_eq!(as_boolean, false);
+
+        assert!(matches!(TryInto::<f64>::try_into(value.clone()).unwrap_err(), Error::MismatchType));
+        assert!(matches!(TryInto::<u64>::try_into(value.clone()).unwrap_err(), Error::MismatchType));
+        assert!(matches!(TryInto::<i64>::try_into(value.clone()).unwrap_err(), Error::MismatchType));
+        assert!(matches!(TryInto::<String>::try_into(value.clone()).unwrap_err(), Error::MismatchType));
     }
 }

--- a/tests/test_app_config.rs
+++ b/tests/test_app_config.rs
@@ -16,7 +16,7 @@ use dotenvy::dotenv;
 use rstest::*;
 
 use appconfiguration_rust_sdk::{
-    AppConfigurationClient, AttrValue, Entity, Feature, Property, Value,
+    AppConfigurationClient, Entity, Feature, Property, Value,
 };
 use std::collections::HashMap;
 use std::env;
@@ -28,7 +28,7 @@ impl Entity for TrivialEntity {
         "TrivialId".into()
     }
 
-    fn get_attributes(&self) -> HashMap<String, AttrValue> {
+    fn get_attributes(&self) -> HashMap<String, Value> {
         HashMap::new()
     }
 }


### PR DESCRIPTION
closes #30 

In https://github.com/IBM/appconfiguration-rust-sdk/pull/30#issuecomment-2545096111 we realize we wanted a simpler API with `get_value<T>`