### PR TITLE
Use `cargo-readme` to generate the README from the Rust docs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Rust
+name: main
 
 on:
   push:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,3 +23,9 @@ jobs:
       run: cargo test --lib --verbose --workspace
     - name: Run tests (documentation tests)
       run: cargo test --doc --verbose --workspace
+
+    - name: Test cargo readme is generated
+      run: |
+        cargo install cargo-readme
+        cargo readme > README.md
+        git diff --exit-code README.md

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,12 @@
 name = "appconfiguration_rust_sdk"
 version = "0.1.0"
 edition = "2021"
+description = "The IBM Cloud App Configuration Rust SDK is used to perform feature flag and property evaluation based on the configuration on IBM Cloud App Configuration service."
+repository = "https://github.com/IBM/appconfiguration-rust-sdk"
+readme = "README.md"
+keywords = ["ibm", "feature-flag", "remote-control"]
+categories = ["config"]
+license = "Apache-2.0"
 
 [dependencies]
 reqwest = { version = "0.12.7", features = ["json", "blocking"] }
@@ -19,3 +25,6 @@ thiserror = "2.0.4"
 [dev-dependencies]
 dotenvy = "0.15.7"
 rstest = "0.23.0"
+
+[badges]
+github = { repository = "IBM/appconfiguration-rust-sdk" }

--- a/README.md
+++ b/README.md
@@ -1,14 +1,9 @@
+[![Workflow Status](https://github.com/IBM/appconfiguration-rust-sdk/workflows/main/badge.svg)](https://github.com/IBM/appconfiguration-rust-sdk/actions?query=workflow%3A%22main%22)
+
 # IBM Cloud App Configuration Rust SDK
 
-The IBM Cloud App Configuration Rust SDK is used to perform feature flag and property evaluation
-based on the configuration on IBM Cloud App Configuration service.
-
-## Table of contents
-
- - [Overview](#overview)
- - [Usage](#usage)
- - [License](#license)
-
+The IBM Cloud App Configuration Rust SDK is used to perform feature flag and property
+evaluation based on the configuration on IBM Cloud App Configuration service.
 
 ## Overview
 
@@ -22,9 +17,38 @@ targeted to segments. Change feature flag states in the cloud to activate or dea
 in your application or environment, when required. You can also manage the properties for distributed
 applications centrally.
 
+## Pre-requisites
+
+You will need the `apikey`, `region` and `guid` for the AppConfiguration you want to connect to
+from your [IBMCloud account](https://cloud.ibm.com/).
+
 ## Usage
 
-This crate is still under development. First release coming soon.
+**Note.-** This crate is still under heavy development. Breaking changes are expected.
+
+Create your client with the context (environment and collection) you want to connect to
+
+```rust
+use appconfiguration_rust_sdk::{AppConfigurationClient, Entity, Result, Value, Feature};
+
+// Create the client connecting to the server
+let client = AppConfigurationClient::new(&apikey, &region, &guid, &environment_id, &collection_id)?;
+
+// Get the feature you want to evaluate for your entities
+let feature = client.get_feature("AB_testing_feature")?;
+
+// Evaluate feature value for each one of your entities
+let user = MyEntity; // Implements Entity
+
+let value_for_this_user = feature.get_value(&user)?.try_into()?;
+if value_for_this_user {
+    println!("Feature {} is active for user {}", feature.get_name()?, user.get_id());
+} else {
+    println!("User {} keeps using the legacy workflow", user.get_id());
+}
+
+```
+
 
 ## License
 

--- a/README.tpl
+++ b/README.tpl
@@ -1,0 +1,10 @@
+{{badges}}
+
+# IBM Cloud App Configuration Rust SDK
+
+{{readme}}
+
+## License
+
+This project is released under the Apache 2.0 license. The license's full text can be found
+in [LICENSE](./LICENSE).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,71 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! The IBM Cloud App Configuration Rust SDK is used to perform feature flag and property
+//! evaluation based on the configuration on IBM Cloud App Configuration service.
+//!
+//! # Overview
+//! 
+//! [IBM Cloud App Configuration](https://cloud.ibm.com/docs/app-configuration) is a centralized
+//! feature management and configuration service on [IBM Cloud](https://www.cloud.ibm.com) for
+//! use with web and mobile applications, microservices, and distributed environments.
+//! 
+//! Instrument your applications with App Configuration Rust SDK, and use the App Configuration
+//! dashboard, API or CLI to define feature flags or properties, organized into collections and
+//! targeted to segments. Change feature flag states in the cloud to activate or deactivate features
+//! in your application or environment, when required. You can also manage the properties for distributed
+//! applications centrally.
+//! 
+//! # Pre-requisites
+//! 
+//! You will need the `apikey`, `region` and `guid` for the AppConfiguration you want to connect to
+//! from your [IBMCloud account](https://cloud.ibm.com/).
+//! 
+//! # Usage
+//! 
+//! **Note.-** This crate is still under heavy development. Breaking changes are expected.
+//! 
+//! Create your client with the context (environment and collection) you want to connect to
+//! 
+//! ```
+//! use appconfiguration_rust_sdk::{AppConfigurationClient, Entity, Result, Value, Feature};
+//! # use std::collections::HashMap;
+//! # pub struct MyEntity;
+//! # impl Entity for MyEntity {
+//! #   fn get_id(&self) -> String {
+//! #     "TrivialId".into()
+//! #   }
+//! #   fn get_attributes(&self) -> HashMap<String, Value> {
+//! #     HashMap::new()
+//! #   }
+//! # }
+//! # fn func() -> Result<()> {
+//! # let apikey: &str = "api_key";
+//! # let region: &str = "us-south";
+//! # let guid: &str = "12345678-1234-1234-1234-12345678abcd";
+//! # let environment_id: &str = "production";
+//! # let collection_id: &str = "ecommerce";
+//! 
+//! // Create the client connecting to the server
+//! let client = AppConfigurationClient::new(&apikey, &region, &guid, &environment_id, &collection_id)?;
+//! 
+//! // Get the feature you want to evaluate for your entities
+//! let feature = client.get_feature("AB_testing_feature")?;
+//! 
+//! // Evaluate feature value for each one of your entities
+//! let user = MyEntity; // Implements Entity
+//! 
+//! let value_for_this_user = feature.get_value(&user)?.try_into()?;
+//! if value_for_this_user {
+//!     println!("Feature {} is active for user {}", feature.get_name()?, user.get_id());
+//! } else {
+//!     println!("User {} keeps using the legacy workflow", user.get_id());
+//! }
+//! 
+//! # Ok(())
+//! # }
+//! ```
+//! 
 mod client;
 mod entity;
 mod errors;


### PR DESCRIPTION
Related to #6 

Use [`cargo-readme`](https://github.com/webern/cargo-readme) to generate the README.md file from the Rust documentation, this way it will by synced with the rendered docs (and moreover, **the examples in the `README.md` file will be tested**).

I've also added a small check to the github actions, so we remember to update the README.md if the Rust documentation has changed.