### PR TITLE
[v0.1.0] Finish documentation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "appconfiguration_rust_sdk"
+name = "appconfiguration"
 version = "0.1.0"
 edition = "2021"
 description = "The IBM Cloud App Configuration Rust SDK is used to perform feature flag and property evaluation based on the configuration on IBM Cloud App Configuration service."

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ from your [IBMCloud account](https://cloud.ibm.com/).
 Create your client with the context (environment and collection) you want to connect to
 
 ```rust
-use appconfiguration_rust_sdk::{
+use appconfiguration::{
     AppConfigurationClient, AppConfigurationClientIBMCloud,
     Entity, Result, Value, Feature
 };

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -14,7 +14,7 @@
 
 use std::{collections::HashMap, env, thread, time::Duration};
 
-use appconfiguration_rust_sdk::{AppConfigurationClient, AppConfigurationClientIBMCloud, Entity, Feature, Property, Value};
+use appconfiguration::{AppConfigurationClient, AppConfigurationClientIBMCloud, Entity, Feature, Property, Value};
 use dotenvy::dotenv;
 use std::error::Error;
 

--- a/src/client/app_configuration_client.rs
+++ b/src/client/app_configuration_client.rs
@@ -21,23 +21,41 @@ use crate::client::property_snapshot::PropertySnapshot;
 
 /// AppConfiguration client for browsing, and evaluating features and properties.
 pub trait AppConfigurationClient {
+    /// Returns the list of features.
+    /// 
+    /// The list contains the `id`s that can be used in [`get_feature`](AppConfigurationClient::get_feature)
+    /// or [`get_feature_proxy`](AppConfigurationClient::get_feature_proxy) to retrieve the actual features.
     fn get_feature_ids(&self) -> Result<Vec<String>>;
 
+    /// Returns a snapshot for a [`Feature`](crate::Feature).
+    /// 
+    /// The instance contains a snapshot with all the values and rules, so it
+    /// will always evaluate the same entities to the same values, no updates
+    /// will be received from the server.
     fn get_feature(&self, feature_id: &str) -> Result<FeatureSnapshot>;
 
-    /// Searches for the feature `feature_id` inside the current configured
-    /// collection, and environment.
-    ///
-    /// Return `Ok(feature)` if the feature exists or `Err` if it does not.
+    /// Returns a proxied [`Feature`](crate::Feature).
+    /// 
+    /// This proxied feature will envaluate entities using the latest information
+    /// available if the client implementation support some kind of live-updates.
     fn get_feature_proxy<'a>(&'a self, feature_id: &str) -> Result<FeatureProxy<'a>>;
 
+    /// Returns the list of properties.
+    /// 
+    /// The list contains the `id`s that can be used in [`get_property`](AppConfigurationClient::get_property)
+    /// or [`get_property_proxy`](AppConfigurationClient::get_property_proxy) to retrieve the actual features.
     fn get_property_ids(&self) -> Result<Vec<String>>;
 
+    /// Returns a snapshot for a [`Property`](crate::Property).
+    /// 
+    /// The instance contains a snapshot with all the values and rules, so it
+    /// will always evaluate the same entities to the same values, no updates
+    /// will be received from the server
     fn get_property(&self, property_id: &str) -> Result<PropertySnapshot>;
 
-    /// Searches for the property `property_id` inside the current configured
-    /// collection, and environment.
-    ///
-    /// Return `Ok(property)` if the feature exists or `Err` if it does not.
+    /// Returns a proxied [`Property`](crate::Property).
+    /// 
+    /// This proxied property will envaluate entities using the latest information
+    /// available if the client implementation support some kind of live-updates.
     fn get_property_proxy(&self, property_id: &str) -> Result<PropertyProxy>;
 }

--- a/src/client/app_configuration_ibm_cloud.rs
+++ b/src/client/app_configuration_ibm_cloud.rs
@@ -40,7 +40,10 @@ pub struct AppConfigurationClientIBMCloud {
 
 impl AppConfigurationClientIBMCloud {
 
-    /// Creates a new [`AppConfigurationClient`] connecting to IBM Cloud
+    /// Creates a new [`AppConfigurationClient`] connecting to IBM Cloud.
+    /// 
+    /// This client keeps a websocket open to the server to receive live-updates
+    /// to features and properties.
     ///
     /// # Arguments
     ///

--- a/src/client/app_configuration_ibm_cloud.rs
+++ b/src/client/app_configuration_ibm_cloud.rs
@@ -95,11 +95,11 @@ impl AppConfigurationClientIBMCloud {
     ) -> Result<ConfigurationSnapshot> {
         let configuration = http::get_configuration(
             // TODO: access_token might expire. This will cause issues with long-running apps
-            &access_token,
-            &region,
-            &guid,
-            &collection_id,
-            &environment_id,
+            access_token,
+            region,
+            guid,
+            collection_id,
+            environment_id,
         )?;
         ConfigurationSnapshot::new(environment_id, configuration)
     }
@@ -186,13 +186,13 @@ impl AppConfigurationClientIBMCloud {
         environment_id: &str,
         collection_id: &str,
     ) -> Result<std::sync::mpsc::Sender<()>> {
-        let access_token = http::get_access_token(&apikey)?;
+        let access_token = http::get_access_token(apikey)?;
         let (socket, _response) = http::get_configuration_monitoring_websocket(
             &access_token,
-            &region,
-            &guid,
-            &collection_id,
-            &environment_id,
+            region,
+            guid,
+            collection_id,
+            environment_id,
         )?;
 
         let sender = Self::update_configuration_on_change(

--- a/src/client/feature_proxy.rs
+++ b/src/client/feature_proxy.rs
@@ -22,6 +22,7 @@ use crate::{Feature, Value};
 use super::feature_snapshot::FeatureSnapshot;
 use super::AppConfigurationClient;
 
+/// Provides live-updated data for a given [`Feature`].
 pub struct FeatureProxy<'a> {
     client: &'a dyn AppConfigurationClient,
     feature_id: String,
@@ -32,6 +33,7 @@ impl<'a> FeatureProxy<'a> {
         Self { client, feature_id }
     }
 
+    /// Take a snapshot of this proxied property
     pub fn snapshot(&self) -> crate::errors::Result<FeatureSnapshot> {
         self.client.get_feature(&self.feature_id)
     }
@@ -55,7 +57,7 @@ impl<'a> Feature for FeatureProxy<'a> {
     }
 }
 
-pub fn random_value(v: &str) -> u32 {
+pub(crate) fn random_value(v: &str) -> u32 {
     let max_hash = u32::MAX;
     (f64::from(hash(v)) / f64::from(max_hash) * 100.0) as u32
 }

--- a/src/client/feature_snapshot.rs
+++ b/src/client/feature_snapshot.rs
@@ -167,7 +167,7 @@ pub mod tests {
             name: "F1".to_string(),
             feature_id: "f1".to_string(),
             kind: ValueKind::Numeric,
-            format: None,
+            _format: None,
             enabled_value: ConfigValue(serde_json::Value::Number((-42).into())),
             disabled_value: ConfigValue(serde_json::Value::Number((2).into())),
             segment_rules,
@@ -208,7 +208,7 @@ pub mod tests {
             name: "F1".to_string(),
             feature_id: "f1".to_string(),
             kind: ValueKind::Numeric,
-            format: None,
+            _format: None,
             enabled_value: ConfigValue(serde_json::Value::Number((-42).into())),
             disabled_value: ConfigValue(serde_json::Value::Number((2).into())),
             segment_rules: Vec::new(),
@@ -230,7 +230,7 @@ pub mod tests {
             name: "F1".to_string(),
             feature_id: "f1".to_string(),
             kind: ValueKind::Numeric,
-            format: None,
+            _format: None,
             enabled_value: ConfigValue(serde_json::Value::Number((-42).into())),
             disabled_value: ConfigValue(serde_json::Value::Number((2).into())),
             segment_rules: vec![TargetingRule {
@@ -249,10 +249,10 @@ pub mod tests {
             HashMap::from([(
                 "some_segment_id".into(),
                 Segment {
-                    name: "".into(),
+                    _name: "".into(),
                     segment_id: "".into(),
-                    description: "".into(),
-                    tags: None,
+                    _description: "".into(),
+                    _tags: None,
                     rules: vec![SegmentRule {
                         attribute_name: "name".into(),
                         operator: "is".into(),
@@ -298,7 +298,7 @@ pub mod tests {
             name: "F1".to_string(),
             feature_id: "f1".to_string(),
             kind: ValueKind::Numeric,
-            format: None,
+            _format: None,
             enabled_value: ConfigValue(serde_json::Value::Number((-42).into())),
             disabled_value: ConfigValue(serde_json::Value::Number((2).into())),
             segment_rules: vec![TargetingRule {
@@ -317,10 +317,10 @@ pub mod tests {
             HashMap::from([(
                 "some_segment_id".into(),
                 Segment {
-                    name: "".into(),
+                    _name: "".into(),
                     segment_id: "".into(),
-                    description: "".into(),
-                    tags: None,
+                    _description: "".into(),
+                    _tags: None,
                     rules: vec![SegmentRule {
                         attribute_name: "name".into(),
                         operator: "is".into(),
@@ -348,7 +348,7 @@ pub mod tests {
             name: "F1".to_string(),
             feature_id: "f1".to_string(),
             kind: ValueKind::Numeric,
-            format: None,
+            _format: None,
             enabled_value: ConfigValue(serde_json::Value::Number((-42).into())),
             disabled_value: ConfigValue(serde_json::Value::Number((2).into())),
             segment_rules: vec![TargetingRule {
@@ -367,10 +367,10 @@ pub mod tests {
             HashMap::from([(
                 "some_segment_id".into(),
                 Segment {
-                    name: "".into(),
+                    _name: "".into(),
                     segment_id: "".into(),
-                    description: "".into(),
-                    tags: None,
+                    _description: "".into(),
+                    _tags: None,
                     rules: vec![SegmentRule {
                         attribute_name: "name".into(),
                         operator: "is".into(),
@@ -396,7 +396,7 @@ pub mod tests {
             name: "F1".to_string(),
             feature_id: "f1".to_string(),
             kind: ValueKind::Numeric,
-            format: None,
+            _format: None,
             enabled_value: ConfigValue(serde_json::Value::Number((-42).into())),
             disabled_value: ConfigValue(serde_json::Value::Number((2).into())),
             segment_rules: vec![
@@ -426,10 +426,10 @@ pub mod tests {
                 (
                     "some_segment_id_1".into(),
                     Segment {
-                        name: "".into(),
+                        _name: "".into(),
                         segment_id: "".into(),
-                        description: "".into(),
-                        tags: None,
+                        _description: "".into(),
+                        _tags: None,
                         rules: vec![SegmentRule {
                             attribute_name: "name".into(),
                             operator: "is".into(),
@@ -440,10 +440,10 @@ pub mod tests {
                 (
                     "some_segment_id_2".into(),
                     Segment {
-                        name: "".into(),
+                        _name: "".into(),
                         segment_id: "".into(),
-                        description: "".into(),
-                        tags: None,
+                        _description: "".into(),
+                        _tags: None,
                         rules: vec![SegmentRule {
                             attribute_name: "name".into(),
                             operator: "is".into(),

--- a/src/client/feature_snapshot.rs
+++ b/src/client/feature_snapshot.rs
@@ -22,6 +22,7 @@ use crate::segment_evaluation::find_applicable_segment_rule_for_entity;
 
 use crate::errors::Result;
 
+/// Provides a snapshot of a [`Feature`].
 #[derive(Debug)]
 pub struct FeatureSnapshot {
     feature: crate::models::Feature,

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -25,5 +25,3 @@ pub(crate) mod property_proxy;
 
 pub use app_configuration_client::AppConfigurationClient;
 pub use app_configuration_ibm_cloud::AppConfigurationClientIBMCloud;
-
-pub const REGION_US_SOUTH: &str = "us-south";

--- a/src/client/property_proxy.rs
+++ b/src/client/property_proxy.rs
@@ -19,6 +19,7 @@ use super::AppConfigurationClient;
 use crate::value::Value;
 use crate::Entity;
 
+/// Provides live-updated data for a given [`Property`].
 pub struct PropertyProxy<'a> {
     client: &'a dyn AppConfigurationClient,
     property_id: String,
@@ -32,6 +33,7 @@ impl<'a> PropertyProxy<'a> {
         }
     }
 
+    /// Take a snapshot of this proxied property
     pub fn snapshot(&self) -> crate::errors::Result<PropertySnapshot> {
         self.client.get_property(&self.property_id)
     }

--- a/src/client/property_snapshot.rs
+++ b/src/client/property_snapshot.rs
@@ -20,6 +20,7 @@ use std::collections::HashMap;
 use crate::errors::Result;
 use crate::segment_evaluation::find_applicable_segment_rule_for_entity;
 
+/// Provides a snapshot of a [`Property`].
 #[derive(Debug)]
 pub struct PropertySnapshot {
     property: crate::models::Property,

--- a/src/client/property_snapshot.rs
+++ b/src/client/property_snapshot.rs
@@ -92,7 +92,7 @@ pub mod tests {
             name: "F1".to_string(),
             property_id: "f1".to_string(),
             kind: ValueKind::Numeric,
-            format: None,
+            _format: None,
             value: ConfigValue(serde_json::Value::Number((-42).into())),
             segment_rules: vec![TargetingRule {
                 rules: vec![Segments {
@@ -102,17 +102,17 @@ pub mod tests {
                 order: 1,
                 rollout_percentage: Some(ConfigValue(serde_json::Value::Number((100).into()))),
             }],
-            tags: None,
+            _tags: None,
         };
         let property = PropertySnapshot::new(
             inner_property,
             HashMap::from([(
                 "some_segment_id_1".into(),
                 Segment {
-                    name: "".into(),
+                    _name: "".into(),
                     segment_id: "".into(),
-                    description: "".into(),
-                    tags: None,
+                    _description: "".into(),
+                    _tags: None,
                     rules: vec![SegmentRule {
                         attribute_name: "name".into(),
                         operator: "is".into(),
@@ -137,7 +137,7 @@ pub mod tests {
             name: "F1".to_string(),
             property_id: "f1".to_string(),
             kind: ValueKind::Numeric,
-            format: None,
+            _format: None,
             value: ConfigValue(serde_json::Value::Number((-42).into())),
             segment_rules: vec![
                 TargetingRule {
@@ -157,7 +157,7 @@ pub mod tests {
                     rollout_percentage: Some(ConfigValue(serde_json::Value::Number((100).into()))),
                 },
             ],
-            tags: None,
+            _tags: None,
         };
         let property = PropertySnapshot::new(
             inner_property,
@@ -165,10 +165,10 @@ pub mod tests {
                 (
                     "some_segment_id_1".into(),
                     Segment {
-                        name: "".into(),
+                        _name: "".into(),
                         segment_id: "".into(),
-                        description: "".into(),
-                        tags: None,
+                        _description: "".into(),
+                        _tags: None,
                         rules: vec![SegmentRule {
                             attribute_name: "name".into(),
                             operator: "is".into(),
@@ -179,10 +179,10 @@ pub mod tests {
                 (
                     "some_segment_id_2".into(),
                     Segment {
-                        name: "".into(),
+                        _name: "".into(),
                         segment_id: "".into(),
-                        description: "".into(),
-                        tags: None,
+                        _description: "".into(),
+                        _tags: None,
                         rules: vec![SegmentRule {
                             attribute_name: "name".into(),
                             operator: "is".into(),

--- a/src/feature.rs
+++ b/src/feature.rs
@@ -36,7 +36,7 @@ pub trait Feature {
     /// # Examples
     ///
     /// ```
-    /// # use appconfiguration_rust_sdk::{AppConfigurationClient, Feature, Result, Entity, Value};
+    /// # use appconfiguration::{AppConfigurationClient, Feature, Result, Entity, Value};
     /// # fn doctest_get_value(client: impl AppConfigurationClient, entity: &impl Entity) -> Result<()> {
     ///     let feature = client.get_feature("my_feature")?;
     ///     let value: Value = feature.get_value(entity)?;
@@ -59,7 +59,7 @@ pub trait Feature {
     /// # Examples
     ///
     /// ```
-    /// # use appconfiguration_rust_sdk::{AppConfigurationClient, Feature, Result, Entity};
+    /// # use appconfiguration::{AppConfigurationClient, Feature, Result, Entity};
     /// # fn doctest_get_value_into(client: impl AppConfigurationClient, entity: &impl Entity) -> Result<()> {
     ///     let feature = client.get_feature("my_f64_feature")?;
     ///     let value: f64 = feature.get_value_into(entity)?;

--- a/src/feature.rs
+++ b/src/feature.rs
@@ -17,17 +17,21 @@ use crate::{Entity, Value};
 
 /// Access to data and evaluation of IBM AppConfiguration features
 pub trait Feature {
-    /// Returns the full name of the feature
+    /// Returns the full name of the feature.
     fn get_name(&self) -> Result<String>;
 
     /// Returns if the feature is enabled or not.
     /// 
-    /// An enabled feature will be evaluated for each [`Entity`] to return the 
-    /// corresponding value. However, disabled features, won't be evaluated and
+    /// An enabled feature should be evaluated for each [`Entity`] to get the 
+    /// corresponding value. However, disabled features won't be evaluated and
     /// will always return the disabled value.
     fn is_enabled(&self) -> Result<bool>;
 
-    /// Returns the evaluated value as a [`Value`] instance
+    /// Evaluates a feature for the given [`Entity`] and returns a [`Value`].
+    /// 
+    /// Use the methods available in [`Value`] to return the actual primitive value. If
+    /// all you want is the primitive value, you can use the method
+    /// [`get_value_into`](Feature::get_value_into) instead.
     /// 
     /// # Examples
     ///
@@ -49,7 +53,8 @@ pub trait Feature {
     /// ```
     fn get_value(&self, entity: &impl Entity) -> Result<Value>;
 
-    /// Returns the evaluated value as the given primitive type, if possible
+    /// Evaluates a feature for the given [`Entity`] and returns its value converted (if possible)
+    /// to the given type.
     /// 
     /// # Examples
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@
 //! Create your client with the context (environment and collection) you want to connect to
 //!
 //! ```
-//! use appconfiguration_rust_sdk::{
+//! use appconfiguration::{
 //!     AppConfigurationClient, AppConfigurationClientIBMCloud,
 //!     Entity, Result, Value, Feature
 //! };

--- a/src/models.rs
+++ b/src/models.rs
@@ -26,7 +26,8 @@ pub(crate) struct Configuration {
 
 #[derive(Debug, Deserialize)]
 pub(crate) struct Environment {
-    name: String,
+    #[serde(rename = "name")]
+    _name: String,
     pub environment_id: String,
     pub features: Vec<Feature>,
     pub properties: Vec<Property>,
@@ -34,10 +35,13 @@ pub(crate) struct Environment {
 
 #[derive(Clone, Debug, Deserialize)]
 pub(crate) struct Segment {
-    pub name: String,
+    #[serde(rename = "name")]
+    pub _name: String,
     pub segment_id: String,
-    pub description: String,
-    pub tags: Option<String>,
+    #[serde(rename = "description")]
+    pub _description: String,
+    #[serde(rename = "tags")]
+    pub _tags: Option<String>,
     pub rules: Vec<SegmentRule>,
 }
 
@@ -45,9 +49,10 @@ pub(crate) struct Segment {
 pub(crate) struct Feature {
     pub name: String,
     pub feature_id: String,
-    #[serde(rename(deserialize = "type"))]
+    #[serde(rename = "type")]
     pub kind: ValueKind,
-    pub format: Option<String>,
+    #[serde(rename = "format")]
+    pub _format: Option<String>,
     pub enabled_value: ConfigValue,
     pub disabled_value: ConfigValue,
     pub segment_rules: Vec<TargetingRule>,
@@ -59,10 +64,12 @@ pub(crate) struct Feature {
 pub(crate) struct Property {
     pub name: String,
     pub property_id: String,
-    #[serde(rename(deserialize = "type"))]
+    #[serde(rename = "type")]
     pub kind: ValueKind,
-    pub tags: Option<String>,
-    pub format: Option<String>,
+    #[serde(rename = "tags")]
+    pub _tags: Option<String>,
+    #[serde(rename = "format")]
+    pub _format: Option<String>,
     pub value: ConfigValue,
     pub segment_rules: Vec<TargetingRule>,
 }
@@ -148,11 +155,11 @@ impl TryFrom<(ValueKind, ConfigValue)> for Value {
             }
             ValueKind::Boolean => value
                 .as_boolean()
-                .map(|v| Value::Boolean(v))
+                .map(Value::Boolean)
                 .ok_or(crate::Error::MismatchType),
             ValueKind::String => value
                 .as_string()
-                .map(|v| Value::String(v))
+                .map(Value::String)
                 .ok_or(crate::Error::MismatchType),
         }
     }
@@ -202,13 +209,13 @@ pub(crate) mod tests {
     pub(crate) fn configuration_feature1_enabled() -> Configuration {
         Configuration {
             environments: vec![Environment {
-                name: "name".to_string(),
+                _name: "name".to_string(),
                 environment_id: "environment_id".to_string(),
                 features: vec![Feature {
                     name: "F1".to_string(),
                     feature_id: "f1".to_string(),
                     kind: ValueKind::Numeric,
-                    format: None,
+                    _format: None,
                     enabled_value: ConfigValue(serde_json::Value::Number(42.into())),
                     disabled_value: ConfigValue(serde_json::Value::Number((-42).into())),
                     segment_rules: Vec::new(),
@@ -225,16 +232,16 @@ pub(crate) mod tests {
     pub(crate) fn configuration_property1_enabled() -> Configuration {
         Configuration {
             environments: vec![Environment {
-                name: "name".to_string(),
+                _name: "name".to_string(),
                 environment_id: "environment_id".to_string(),
                 properties: vec![Property {
                     name: "P1".to_string(),
                     property_id: "p1".to_string(),
                     kind: ValueKind::Numeric,
-                    format: None,
+                    _format: None,
                     value: ConfigValue(serde_json::Value::Number(42.into())),
                     segment_rules: Vec::new(),
-                    tags: None,
+                    _tags: None,
                 }],
                 features: Vec::new(),
             }],

--- a/src/property.rs
+++ b/src/property.rs
@@ -17,10 +17,14 @@ use crate::{Entity, Value};
 
 /// Access to data and evaluation of IBM AppConfiguration properties
 pub trait Property {
-    /// Returns the full name of the property
+    /// Returns the full name of the property.
     fn get_name(&self) -> Result<String>;
 
-    /// Returns the evaluated value as a [`Value`] instance
+    /// Evaluates a property for the given [`Entity`] and returns a [`Value`].
+    /// 
+    /// Use the methods available in [`Value`] to return the actual primitive value. If
+    /// all you want is the primitive value, you can use the method
+    /// [`get_value_into`](Property::get_value_into) instead.
     /// 
     /// # Examples
     ///
@@ -42,7 +46,8 @@ pub trait Property {
     /// ```
     fn get_value(&self, entity: &impl Entity) -> Result<Value>;
 
-    /// Returns the evaluated value as the given primitive type, if possible
+    /// Evaluates a property for the given [`Entity`] and returns its value converted (if possible)
+    /// to the given type.
     /// 
     /// # Examples
     ///

--- a/src/property.rs
+++ b/src/property.rs
@@ -29,7 +29,7 @@ pub trait Property {
     /// # Examples
     ///
     /// ```
-    /// # use appconfiguration_rust_sdk::{AppConfigurationClient, Property, Result, Entity, Value};
+    /// # use appconfiguration::{AppConfigurationClient, Property, Result, Entity, Value};
     /// # fn doctest_get_value(client: impl AppConfigurationClient, entity: &impl Entity) -> Result<()> {
     ///     let property = client.get_property("my_property")?;
     ///     let value: Value = property.get_value(entity)?;
@@ -52,7 +52,7 @@ pub trait Property {
     /// # Examples
     ///
     /// ```
-    /// # use appconfiguration_rust_sdk::{AppConfigurationClient, Property, Result, Entity};
+    /// # use appconfiguration::{AppConfigurationClient, Property, Result, Entity};
     /// # fn doctest_get_value_into(client: impl AppConfigurationClient, entity: &impl Entity) -> Result<()> {
     ///     let property = client.get_property("my_bool_feature")?;
     ///     let value: bool = property.get_value_into(entity)?;

--- a/src/segment_evaluation/errors.rs
+++ b/src/segment_evaluation/errors.rs
@@ -26,10 +26,11 @@ pub(crate) enum SegmentEvaluationError {
 }
 
 #[derive(Debug, Error)]
-#[error("Operation '{}' '{}' '{}' failed to evaluate: {}", segment_rule.attribute_name, segment_rule.operator,  value, source)]
+#[error("Operation '{}' '{}' '{}' failed to evaluate: {}", segment_rule_attribute_name, segment_rule_operator,  value, source)]
 pub(crate) struct SegmentEvaluationErrorKind {
     pub(crate) segment_id: String,
-    pub(crate) segment_rule: SegmentRule,
+    pub(crate) segment_rule_attribute_name: String,
+    pub(crate) segment_rule_operator: String,
     pub(crate) value: String,
     pub(crate) source: CheckOperatorErrorDetail,
 }
@@ -39,7 +40,8 @@ impl From<(CheckOperatorErrorDetail, &Segment, &SegmentRule, &String)> for Segme
         let (source, segment, segment_rule, value) = value;
         Self::SegmentEvaluationFailed(SegmentEvaluationErrorKind {
             segment_id: segment.segment_id.clone(),
-            segment_rule: segment_rule.clone(),
+            segment_rule_attribute_name: segment_rule.attribute_name.clone(),
+            segment_rule_operator: segment_rule.operator.clone(),
             value: value.clone(),
             source,
         })

--- a/src/segment_evaluation/mod.rs
+++ b/src/segment_evaluation/mod.rs
@@ -281,7 +281,7 @@ pub mod tests {
             panic!("Error type mismatch!");
         };
         assert_eq!(error.segment_id, "some_segment_id_1");
-        assert_eq!(error.segment_rule.attribute_name, "name");
+        assert_eq!(error.segment_rule_attribute_name, "name");
         assert_eq!(error.value, "heinz");
     }
 }

--- a/src/segment_evaluation/mod.rs
+++ b/src/segment_evaluation/mod.rs
@@ -183,10 +183,10 @@ pub mod tests {
         HashMap::from([(
             "some_segment_id_1".into(),
             Segment {
-                name: "".into(),
+                _name: "".into(),
                 segment_id: "some_segment_id_1".into(),
-                description: "".into(),
-                tags: None,
+                _description: "".into(),
+                _tags: None,
                 rules: vec![SegmentRule {
                     attribute_name: "name".into(),
                     operator: "is".into(),

--- a/tests/test_app_config.rs
+++ b/tests/test_app_config.rs
@@ -15,7 +15,7 @@
 use dotenvy::dotenv;
 use rstest::*;
 
-use appconfiguration_rust_sdk::{
+use appconfiguration::{
     AppConfigurationClient, AppConfigurationClientIBMCloud, Entity, Feature, Property, Value,
 };
 use std::collections::HashMap;


### PR DESCRIPTION
- [x] Address all `cargo clippy` warnings
- [x] Finish documentation (closes #6)
- [x] Renames the crate from `appconfiguration_rust_sdk` to `appconfiguration` 