### PR TITLE
Use release-plz as the release tool

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    # Check for updates every Monday
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,0 +1,53 @@
+name: Release-plz
+
+permissions:
+  pull-requests: write
+  contents: write
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+
+  # Release unpublished packages.
+  release-plz-release:
+    name: Release-plz release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Run release-plz
+        uses: release-plz/action@v0.5
+        with:
+          command: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+  # Create a PR with the new versions and changelog, preparing the next release.
+  release-plz-pr:
+    name: Release-plz PR
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-plz-${{ github.ref }}
+      cancel-in-progress: false
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Run release-plz
+        uses: release-plz/action@v0.5
+        with:
+          command: release-pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/release.toml
+++ b/release.toml
@@ -1,7 +1,0 @@
-# We use [cargo-release](https://github.com/crate-ci/cargo-release/tree/master)
-# to execute the release process.
-consolidate-commits = false
-allow-branch = ["main"]
-sign-commit = true
-sign-tag = true
-push-remote = "git@github.com:IBM/appconfiguration-rust-sdk.git"


### PR DESCRIPTION
https://release-plz.dev/

It adds one GH action with two jobs that are triggered for every commit to `main`
 * `release-plz-release`: it will release the package version if it was not released to crates.io yet (it uses @jgsogo token secret). **Note.-**, when this PR is merged (if everything is right) the first version of the crate will be released (closes #39).
 * `release-plz-pr`: keeps a PR updated with all the changes that are being accumulated for the next release. If using [conventional commits](https://www.conventionalcommits.org/), it will also update the next semver version in this PR according to the changes.

---

I've also added here the `dependabot.yml` to update the GH actions version automatically.