### PR TITLE
feat: Add `AppConfigurationClient` implementation for offline mode

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2024-12-18T09:36:50Z",
+  "generated_at": "2025-01-14T16:18:25Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -77,11 +77,29 @@
     }
   ],
   "results": {
+    "src/client/app_configuration_ibm_cloud.rs": [
+      {
+        "hashed_secret": "fb34629c9af1ed4045b5d6f287426276b2be3a1e",
+        "is_verified": false,
+        "line_number": 185,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
     "src/client/http.rs": [
       {
         "hashed_secret": "91271e4ebcf7a9793e252299b9a2c77c8d964325",
         "is_verified": false,
         "line_number": 42,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "src/lib.rs": [
+      {
+        "hashed_secret": "df1431b489758b92c84bdec3c9283b96066a44b8",
+        "is_verified": false,
+        "line_number": 57,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/src/client/app_configuration_offline.rs
+++ b/src/client/app_configuration_offline.rs
@@ -1,0 +1,164 @@
+// (C) Copyright IBM Corp. 2024.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::client::cache::ConfigurationSnapshot;
+pub use crate::client::feature_proxy::FeatureProxy;
+use crate::client::feature_snapshot::FeatureSnapshot;
+pub use crate::client::property_proxy::PropertyProxy;
+use crate::client::property_snapshot::PropertySnapshot;
+use crate::errors::{ConfigurationAccessError, DeserializationError, Error, Result};
+use crate::models::{Configuration, Segment};
+use std::collections::{HashMap, HashSet};
+
+use super::AppConfigurationClient;
+
+/// AppConfiguration client using a local file with a snapshot
+#[derive(Debug)]
+pub struct AppConfigurationOffline {
+    pub(crate) config_snapshot: ConfigurationSnapshot,
+}
+
+impl AppConfigurationOffline {
+    /// Creates a new [`AppConfigurationClient`] taking the configuration from a local file.
+    ///
+    /// # Arguments
+    ///
+    /// * `filepath` - The file with the configuration.
+    /// * `region` - Region name where the App Configuration service instance is created
+    /// * `guid` - Instance ID of the App Configuration service. Obtain it from the service credentials section of the App Configuration dashboard
+    /// * `environment_id` - ID of the environment created in App Configuration service instance under the Environments section.
+    /// * `collection_id` - ID of the collection created in App Configuration service instance under the Collections section
+    pub fn new(filepath: &std::path::Path, environment_id: &str) -> Result<Self> {
+        let file = std::fs::File::open(filepath).map_err(|_| {
+            Error::Other(format!(
+                "File '{}' doesn't exist or cannot be read",
+                filepath.display()
+            ))
+        })?;
+        let reader = std::io::BufReader::new(file);
+
+        let configuration: Configuration = serde_json::from_reader(reader).map_err(|e| {
+            Error::DeserializationError(DeserializationError {
+                string: format!(
+                    "Error deserializing Configuration from file '{}'",
+                    filepath.display()
+                ),
+                source: e.into(),
+            })
+        })?;
+        let config_snapshot = ConfigurationSnapshot::new(environment_id, configuration)?;
+
+        Ok(Self { config_snapshot })
+    }
+}
+
+impl AppConfigurationClient for AppConfigurationOffline {
+    fn get_feature_ids(&self) -> Result<Vec<String>> {
+        Ok(self.config_snapshot.features.keys().cloned().collect())
+    }
+
+    fn get_feature(&self, feature_id: &str) -> Result<FeatureSnapshot> {
+        // Get the feature from the snapshot
+        let feature = self.config_snapshot.get_feature(feature_id)?;
+
+        // Get the segment rules that apply to this feature
+        let segments = {
+            let all_segment_ids = feature
+                .segment_rules
+                .iter()
+                .flat_map(|targeting_rule| {
+                    targeting_rule
+                        .rules
+                        .iter()
+                        .flat_map(|segment| &segment.segments)
+                })
+                .cloned()
+                .collect::<HashSet<String>>();
+            let segments: HashMap<String, Segment> = self
+                .config_snapshot
+                .segments
+                .iter()
+                .filter(|&(key, _)| all_segment_ids.contains(key))
+                .map(|(k, v)| (k.clone(), v.clone()))
+                .collect();
+
+            // Integrity DB check: all segment_ids should be available in the snapshot
+            if all_segment_ids.len() != segments.len() {
+                return Err(ConfigurationAccessError::MissingSegments {
+                    resource_id: feature_id.to_string(),
+                }
+                .into());
+            }
+
+            segments
+        };
+
+        Ok(FeatureSnapshot::new(feature.clone(), segments))
+    }
+
+    fn get_feature_proxy<'a>(&'a self, feature_id: &str) -> Result<FeatureProxy<'a>> {
+        // FIXME: there is and was no validation happening if the feature exists.
+        // Comments and error messages in FeatureProxy suggest that this should happen here.
+        // same applies for properties.
+        Ok(FeatureProxy::new(self, feature_id.to_string()))
+    }
+
+    fn get_property_ids(&self) -> Result<Vec<String>> {
+        Ok(self.config_snapshot.properties.keys().cloned().collect())
+    }
+
+    fn get_property(&self, property_id: &str) -> Result<PropertySnapshot> {
+        // Get the property from the snapshot
+        let property = self.config_snapshot.get_property(property_id)?;
+
+        // Get the segment rules that apply to this property
+        let segments = {
+            let all_segment_ids = property
+                .segment_rules
+                .iter()
+                .flat_map(|targeting_rule| {
+                    targeting_rule
+                        .rules
+                        .iter()
+                        .flat_map(|segment| &segment.segments)
+                })
+                .cloned()
+                .collect::<HashSet<String>>();
+            let segments: HashMap<String, Segment> = self
+                .config_snapshot
+                .segments
+                .iter()
+                .filter(|&(key, _)| all_segment_ids.contains(key))
+                .map(|(k, v)| (k.clone(), v.clone()))
+                .collect();
+
+            // Integrity DB check: all segment_ids should be available in the snapshot
+            if all_segment_ids.len() != segments.len() {
+                // FIXME: Return some kind of DBIntegrity error
+                return Err(ConfigurationAccessError::MissingSegments {
+                    resource_id: property_id.to_string(),
+                }
+                .into());
+            }
+
+            segments
+        };
+
+        Ok(PropertySnapshot::new(property.clone(), segments))
+    }
+
+    fn get_property_proxy(&self, property_id: &str) -> Result<PropertyProxy> {
+        Ok(PropertyProxy::new(self, property_id.to_string()))
+    }
+}

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -14,6 +14,7 @@
 
 mod app_configuration_client;
 mod app_configuration_ibm_cloud;
+mod app_configuration_offline;
 
 pub(crate) mod cache;
 pub(crate) mod feature_proxy;
@@ -24,3 +25,4 @@ pub(crate) mod property_snapshot;
 
 pub use app_configuration_client::AppConfigurationClient;
 pub use app_configuration_ibm_cloud::AppConfigurationClientIBMCloud;
+pub use app_configuration_offline::AppConfigurationOffline;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,7 @@ mod property;
 mod segment_evaluation;
 mod value;
 
-pub use client::{AppConfigurationClient, AppConfigurationClientIBMCloud};
+pub use client::{AppConfigurationClient, AppConfigurationClientIBMCloud, AppConfigurationOffline};
 pub use entity::Entity;
 pub use errors::{Error, Result};
 pub use feature::Feature;


### PR DESCRIPTION
closes #1 

This new `AppConfigurationOffline` implementation just reads the configuration from a JSON file and implements `AppConfigurationClient` trait (of course, there is no update mechanism running behind the scenes)