### PR TITLE
chore: Use the `AppConfigurationOffline` implementation in testing

### DIFF
--- a/src/client/app_configuration_ibm_cloud.rs
+++ b/src/client/app_configuration_ibm_cloud.rs
@@ -32,8 +32,8 @@ use super::AppConfigurationClient;
 /// AppConfiguration client connection to IBM Cloud.
 #[derive(Debug)]
 pub struct AppConfigurationClientIBMCloud {
-    pub(crate) latest_config_snapshot: Arc<Mutex<ConfigurationSnapshot>>,
-    pub(crate) _thread_terminator: std::sync::mpsc::Sender<()>,
+    latest_config_snapshot: Arc<Mutex<ConfigurationSnapshot>>,
+    _thread_terminator: std::sync::mpsc::Sender<()>,
 }
 
 impl AppConfigurationClientIBMCloud {
@@ -280,5 +280,90 @@ impl AppConfigurationClient for AppConfigurationClientIBMCloud {
 
     fn get_property_proxy(&self, property_id: &str) -> Result<PropertyProxy> {
         Ok(PropertyProxy::new(self, property_id.to_string()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::tests::{
+        configuration_feature1_enabled, configuration_property1_enabled,
+        example_configuration_enterprise,
+    };
+    use crate::{models::Configuration, Feature, Property};
+    use rstest::rstest;
+
+    #[rstest]
+    fn test_get_feature_persistence(
+        example_configuration_enterprise: Configuration,
+        configuration_feature1_enabled: Configuration,
+    ) {
+        let client = {
+            let configuration_snapshot =
+                ConfigurationSnapshot::new("dev", example_configuration_enterprise).unwrap();
+
+            let (sender, _) = std::sync::mpsc::channel();
+
+            AppConfigurationClientIBMCloud {
+                latest_config_snapshot: Arc::new(Mutex::new(configuration_snapshot)),
+                _thread_terminator: sender,
+            }
+        };
+
+        let feature = client.get_feature("f1").unwrap();
+
+        let entity = crate::entity::tests::TrivialEntity {};
+        let feature_value1 = feature.get_value(&entity).unwrap();
+
+        // We simulate an update of the configuration:
+        let configuration_snapshot =
+            ConfigurationSnapshot::new("environment_id", configuration_feature1_enabled).unwrap();
+        *client.latest_config_snapshot.lock().unwrap() = configuration_snapshot;
+        // The feature value should not have changed (as we did not retrieve it again)
+        let feature_value2 = feature.get_value(&entity).unwrap();
+        assert_eq!(feature_value2, feature_value1);
+
+        // Now we retrieve the feature again:
+        let feature = client.get_feature("f1").unwrap();
+        // And expect the updated value
+        let feature_value3 = feature.get_value(&entity).unwrap();
+        assert_ne!(feature_value3, feature_value1);
+    }
+
+    #[rstest]
+    fn test_get_property_persistence(
+        example_configuration_enterprise: Configuration,
+        configuration_property1_enabled: Configuration,
+    ) {
+        let client = {
+            let configuration_snapshot =
+                ConfigurationSnapshot::new("dev", example_configuration_enterprise).unwrap();
+
+            let (sender, _) = std::sync::mpsc::channel();
+
+            AppConfigurationClientIBMCloud {
+                latest_config_snapshot: Arc::new(Mutex::new(configuration_snapshot)),
+                _thread_terminator: sender,
+            }
+        };
+
+        let property = client.get_property("p1").unwrap();
+
+        let entity = crate::entity::tests::TrivialEntity {};
+        let property_value1 = property.get_value(&entity).unwrap();
+
+        // We simulate an update of the configuration:
+        let configuration_snapshot =
+            ConfigurationSnapshot::new("environment_id", configuration_property1_enabled).unwrap();
+        *client.latest_config_snapshot.lock().unwrap() = configuration_snapshot;
+        // The property value should not have changed (as we did not retrieve it again)
+        let property_value2 = property.get_value(&entity).unwrap();
+        assert_eq!(property_value2, property_value1);
+
+        // Now we retrieve the property again:
+        let property = client.get_property("p1").unwrap();
+        // And expect the updated value
+        let property_value3 = property.get_value(&entity).unwrap();
+        assert_ne!(property_value3, property_value1);
     }
 }

--- a/src/client/feature_snapshot.rs
+++ b/src/client/feature_snapshot.rs
@@ -221,7 +221,7 @@ pub mod tests {
         };
         let feature = FeatureSnapshot::new(inner_feature, HashMap::new());
 
-        let entity = crate::tests::TrivialEntity {};
+        let entity = crate::entity::tests::TrivialEntity {};
         let value = feature.get_value(&entity).unwrap();
         assert!(matches!(value, Value::Int64(ref v) if v == &2));
     }

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -27,3 +27,20 @@ pub trait Entity {
         HashMap::new()
     }
 }
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::*;
+
+    pub struct TrivialEntity;
+
+    impl Entity for TrivialEntity {
+        fn get_id(&self) -> String {
+            "TrivialId".into()
+        }
+
+        fn get_attributes(&self) -> HashMap<String, Value> {
+            HashMap::new()
+        }
+    }
+}

--- a/src/models.rs
+++ b/src/models.rs
@@ -193,13 +193,21 @@ pub(crate) mod tests {
     use std::{fs, path::PathBuf};
 
     #[fixture]
-    pub(crate) fn example_configuration_enterprise() -> Configuration {
+    // Provides the path to the configuration data file
+    pub(crate) fn example_configuration_enterprise_path() -> PathBuf {
         // Create a configuration object from the data files
-
         let mut mocked_data = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         mocked_data.push("data/data-dump-enterprise-plan-sdk-testing.json");
+        mocked_data
+    }
 
-        let content = fs::File::open(mocked_data).expect("file should open read only");
+    #[fixture]
+    // Create a [`Configuration`] object from the data files
+    pub(crate) fn example_configuration_enterprise(
+        example_configuration_enterprise_path: PathBuf,
+    ) -> Configuration {
+        let content = fs::File::open(example_configuration_enterprise_path)
+            .expect("file should open read only");
         let configuration: Configuration =
             serde_json::from_reader(content).expect("Error parsing JSON into Configuration");
         configuration

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::collections::HashMap;
+use std::path::PathBuf;
 
 mod test_get_feature;
 mod test_get_feature_ids;
@@ -20,26 +21,12 @@ mod test_get_property;
 mod test_get_property_ids;
 mod test_using_example_data;
 
-use crate::client::cache::ConfigurationSnapshot;
-use crate::client::AppConfigurationClientIBMCloud;
-use crate::models::tests::example_configuration_enterprise;
-use crate::models::Configuration;
+use crate::client::{AppConfigurationClient, AppConfigurationOffline};
+use crate::models::tests::example_configuration_enterprise_path;
+
 use crate::Entity;
 use crate::Value;
 use rstest::fixture;
-use std::sync::{Arc, Mutex};
-
-pub struct TrivialEntity;
-
-impl Entity for TrivialEntity {
-    fn get_id(&self) -> String {
-        "TrivialId".into()
-    }
-
-    fn get_attributes(&self) -> HashMap<String, Value> {
-        HashMap::new()
-    }
-}
 
 pub struct GenericEntity {
     pub id: String,
@@ -58,16 +45,7 @@ impl Entity for GenericEntity {
 
 #[fixture]
 fn client_enterprise(
-    example_configuration_enterprise: Configuration,
-) -> AppConfigurationClientIBMCloud {
-    let configuration_snapshot =
-        ConfigurationSnapshot::new("dev", example_configuration_enterprise).unwrap();
-
-    // Create the client
-    let (sender, _) = std::sync::mpsc::channel();
-
-    AppConfigurationClientIBMCloud {
-        latest_config_snapshot: Arc::new(Mutex::new(configuration_snapshot)),
-        _thread_terminator: sender,
-    }
+    example_configuration_enterprise_path: PathBuf,
+) -> Box<dyn AppConfigurationClient> {
+    Box::new(AppConfigurationOffline::new(&example_configuration_enterprise_path, "dev").unwrap())
 }

--- a/src/tests/test_get_feature.rs
+++ b/src/tests/test_get_feature.rs
@@ -13,46 +13,20 @@
 // limitations under the License.
 
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
 
 use crate::models::Configuration;
 
 use crate::client::cache::ConfigurationSnapshot;
-use crate::client::{AppConfigurationClient, AppConfigurationClientIBMCloud};
-use crate::Value;
+use crate::client::AppConfigurationClient;
+use crate::{AppConfigurationOffline, Value};
 use rstest::*;
 
 use super::client_enterprise;
 use crate::feature::Feature;
-use crate::models::tests::{configuration_feature1_enabled, configuration_unordered_segment_rules};
+use crate::models::tests::configuration_unordered_segment_rules;
 
 #[rstest]
-fn test_get_feature_persistence(
-    client_enterprise: AppConfigurationClientIBMCloud,
-    configuration_feature1_enabled: Configuration,
-) {
-    let feature = client_enterprise.get_feature("f1").unwrap();
-
-    let entity = super::TrivialEntity {};
-    let feature_value1 = feature.get_value(&entity).unwrap();
-
-    // We simulate an update of the configuration:
-    let configuration_snapshot =
-        ConfigurationSnapshot::new("environment_id", configuration_feature1_enabled).unwrap();
-    *client_enterprise.latest_config_snapshot.lock().unwrap() = configuration_snapshot;
-    // The feature value should not have changed (as we did not retrieve it again)
-    let feature_value2 = feature.get_value(&entity).unwrap();
-    assert_eq!(feature_value2, feature_value1);
-
-    // Now we retrieve the feature again:
-    let feature = client_enterprise.get_feature("f1").unwrap();
-    // And expect the updated value
-    let feature_value3 = feature.get_value(&entity).unwrap();
-    assert_ne!(feature_value3, feature_value1);
-}
-
-#[rstest]
-fn test_get_feature_doesnt_exist(client_enterprise: AppConfigurationClientIBMCloud) {
+fn test_get_feature_doesnt_exist(client_enterprise: Box<dyn AppConfigurationClient>) {
     let feature = client_enterprise.get_feature("non-existing");
     assert!(feature.is_err());
     assert_eq!(
@@ -63,17 +37,11 @@ fn test_get_feature_doesnt_exist(client_enterprise: AppConfigurationClientIBMClo
 
 #[rstest]
 fn test_get_feature_ordered(configuration_unordered_segment_rules: Configuration) {
-    let configuration_snapshot =
+    let config_snapshot =
         ConfigurationSnapshot::new("environment_id", configuration_unordered_segment_rules)
             .unwrap();
 
-    // Create the client
-    let (sender, _) = std::sync::mpsc::channel();
-
-    let client = AppConfigurationClientIBMCloud {
-        latest_config_snapshot: Arc::new(Mutex::new(configuration_snapshot)),
-        _thread_terminator: sender,
-    };
+    let client = AppConfigurationOffline { config_snapshot };
 
     let entity = crate::tests::GenericEntity {
         id: "a2".into(),

--- a/src/tests/test_get_feature_ids.rs
+++ b/src/tests/test_get_feature_ids.rs
@@ -13,11 +13,11 @@
 // limitations under the License.
 
 use super::client_enterprise;
-use crate::client::{AppConfigurationClient, AppConfigurationClientIBMCloud};
+use crate::client::AppConfigurationClient;
 use rstest::*;
 
 #[rstest]
-fn test_get_feature_ids(client_enterprise: AppConfigurationClientIBMCloud) {
+fn test_get_feature_ids(client_enterprise: Box<dyn AppConfigurationClient>) {
     let mut features = client_enterprise.get_feature_ids().unwrap();
     features.sort();
     assert_eq!(

--- a/src/tests/test_get_property.rs
+++ b/src/tests/test_get_property.rs
@@ -13,48 +13,20 @@
 // limitations under the License.
 
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
 
 use crate::models::Configuration;
 
 use crate::client::cache::ConfigurationSnapshot;
-use crate::client::{AppConfigurationClient, AppConfigurationClientIBMCloud};
+use crate::client::{AppConfigurationClient, AppConfigurationOffline};
 use crate::Value;
 use rstest::*;
 
 use super::client_enterprise;
-use crate::models::tests::{
-    configuration_property1_enabled, configuration_unordered_segment_rules,
-};
+use crate::models::tests::configuration_unordered_segment_rules;
 use crate::property::Property;
 
 #[rstest]
-fn test_get_property_persistence(
-    client_enterprise: AppConfigurationClientIBMCloud,
-    configuration_property1_enabled: Configuration,
-) {
-    let property = client_enterprise.get_property("p1").unwrap();
-
-    let entity = super::TrivialEntity {};
-    let property_value1 = property.get_value(&entity).unwrap();
-
-    // We simulate an update of the configuration:
-    let configuration_snapshot =
-        ConfigurationSnapshot::new("environment_id", configuration_property1_enabled).unwrap();
-    *client_enterprise.latest_config_snapshot.lock().unwrap() = configuration_snapshot;
-    // The property value should not have changed (as we did not retrieve it again)
-    let property_value2 = property.get_value(&entity).unwrap();
-    assert_eq!(property_value2, property_value1);
-
-    // Now we retrieve the property again:
-    let property = client_enterprise.get_property("p1").unwrap();
-    // And expect the updated value
-    let property_value3 = property.get_value(&entity).unwrap();
-    assert_ne!(property_value3, property_value1);
-}
-
-#[rstest]
-fn test_get_property_doesnt_exist(client_enterprise: AppConfigurationClientIBMCloud) {
+fn test_get_property_doesnt_exist(client_enterprise: Box<dyn AppConfigurationClient>) {
     let property = client_enterprise.get_property("non-existing");
     assert!(property.is_err());
     assert_eq!(
@@ -65,17 +37,11 @@ fn test_get_property_doesnt_exist(client_enterprise: AppConfigurationClientIBMCl
 
 #[rstest]
 fn test_get_property_ordered(configuration_unordered_segment_rules: Configuration) {
-    let configuration_snapshot =
+    let config_snapshot =
         ConfigurationSnapshot::new("environment_id", configuration_unordered_segment_rules)
             .unwrap();
 
-    // Create the client
-    let (sender, _) = std::sync::mpsc::channel();
-
-    let client = AppConfigurationClientIBMCloud {
-        latest_config_snapshot: Arc::new(Mutex::new(configuration_snapshot)),
-        _thread_terminator: sender,
-    };
+    let client = AppConfigurationOffline { config_snapshot };
 
     let entity = crate::tests::GenericEntity {
         id: "a2".into(),

--- a/src/tests/test_get_property_ids.rs
+++ b/src/tests/test_get_property_ids.rs
@@ -13,11 +13,11 @@
 // limitations under the License.
 
 use super::client_enterprise;
-use crate::client::{AppConfigurationClient, AppConfigurationClientIBMCloud};
+use crate::client::AppConfigurationClient;
 use rstest::*;
 
 #[rstest]
-fn test_get_property_ids(client_enterprise: AppConfigurationClientIBMCloud) {
+fn test_get_property_ids(client_enterprise: Box<dyn AppConfigurationClient>) {
     let mut properties = client_enterprise.get_property_ids().unwrap();
     properties.sort();
     assert_eq!(

--- a/src/tests/test_using_example_data.rs
+++ b/src/tests/test_using_example_data.rs
@@ -12,15 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::client::{AppConfigurationClient, AppConfigurationClientIBMCloud};
-use crate::tests::TrivialEntity;
+use crate::client::AppConfigurationClient;
+use crate::entity::tests::TrivialEntity;
 use rstest::*;
 
 use super::client_enterprise;
 use crate::{Feature, Property, Value};
 
 #[rstest]
-fn test_get_a_specific_feature(client_enterprise: AppConfigurationClientIBMCloud) {
+fn test_get_a_specific_feature(client_enterprise: Box<dyn AppConfigurationClient>) {
     let specific_feature = client_enterprise.get_feature_proxy("f1").unwrap();
 
     let name = specific_feature.get_name().unwrap();
@@ -33,7 +33,7 @@ fn test_get_a_specific_feature(client_enterprise: AppConfigurationClientIBMCloud
 }
 
 #[rstest]
-fn test_get_a_specific_property(client_enterprise: AppConfigurationClientIBMCloud) {
+fn test_get_a_specific_property(client_enterprise: Box<dyn AppConfigurationClient>) {
     let property = client_enterprise.get_property_proxy("p1").unwrap();
 
     let name = property.get_name().unwrap();


### PR DESCRIPTION
Tests use a hardcoded JSON file to read the configuration from it. The offline implementation provides exactly this functionality.