### PR TITLE
[refact] Introduce NetworkResult and NetworkError types

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -2,6 +2,7 @@ use std::sync::PoisonError;
 
 use thiserror::Error;
 
+use crate::network::errors::NetworkError;
 use crate::segment_evaluation::errors::SegmentEvaluationError;
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -29,9 +30,6 @@ pub enum Error {
     MismatchType,
 
     #[error(transparent)]
-    ReqwestError(#[from] reqwest::Error),
-
-    #[error(transparent)]
     TungsteniteError(#[from] tungstenite::Error),
 
     #[error("Protocol error. Unexpected data received from server")]
@@ -48,6 +46,9 @@ pub enum Error {
 
     #[error("Failed to evaluate entity: {0}")]
     EntityEvaluationError(EntityEvaluationError),
+
+    #[error(transparent)]
+    NetworkError(#[from] NetworkError),
 
     #[error("{0}")]
     Other(String),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,6 +105,6 @@ pub use value::Value;
 #[cfg(feature = "http_client")]
 pub use client::AppConfigurationClientHttp;
 #[cfg(feature = "http_client")]
-pub use network::{ServiceAddress, TokenProvider};
+pub use network::{NetworkError, NetworkResult, ServiceAddress, TokenProvider};
 #[cfg(test)]
 mod tests;

--- a/src/network/errors.rs
+++ b/src/network/errors.rs
@@ -12,14 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod errors;
-pub(crate) mod http_client;
-mod token_provider;
+use thiserror::Error;
 
-pub(crate) use http_client::ServerClientImpl;
-pub use http_client::ServiceAddress;
-pub(crate) use token_provider::IBMCloudTokenProvider;
-pub use token_provider::TokenProvider;
+#[derive(Debug, Error)]
+pub enum NetworkError {
+    #[error(transparent)]
+    ReqwestError(#[from] reqwest::Error),
 
-pub use errors::NetworkError;
-pub type NetworkResult<T> = std::result::Result<T, NetworkError>;
+    #[error(transparent)]
+    TungsteniteError(#[from] tungstenite::Error),
+
+    #[error("Protocol error. Unexpected data received from server")]
+    ProtocolError,
+
+    #[error("Cannot parse '{0}' as URL")]
+    UrlParseError(String),
+
+    #[error("Invalid header value for '{0}'")]
+    InvalidHeaderValue(String),
+}

--- a/src/network/token_provider.rs
+++ b/src/network/token_provider.rs
@@ -14,12 +14,12 @@
 
 use std::collections::HashMap;
 
-use crate::{Error, Result};
+use super::{NetworkError, NetworkResult};
 use reqwest::blocking::Client;
 use serde::Deserialize;
 
 pub trait TokenProvider: std::fmt::Debug + Send + Sync {
-    fn get_access_token(&self) -> Result<String>;
+    fn get_access_token(&self) -> NetworkResult<String>;
 }
 
 #[derive(Debug)]
@@ -41,7 +41,7 @@ struct AccessTokenResponse {
 }
 
 impl TokenProvider for IBMCloudTokenProvider {
-    fn get_access_token(&self) -> Result<String> {
+    fn get_access_token(&self) -> NetworkResult<String> {
         let mut form_data = HashMap::new();
         form_data.insert("reponse_type".to_string(), "cloud_iam".to_string());
         form_data.insert(
@@ -56,9 +56,9 @@ impl TokenProvider for IBMCloudTokenProvider {
             .header("Accept", "application/json")
             .form(&form_data)
             .send()
-            .map_err(Error::ReqwestError)?
+            .map_err(NetworkError::ReqwestError)?
             .json::<AccessTokenResponse>()
-            .map_err(Error::ReqwestError)? // FIXME: This is a deserialization error (extract it from Reqwest)
+            .map_err(NetworkError::ReqwestError)? // FIXME: This is a deserialization error (extract it from Reqwest)
             .access_token)
     }
 }

--- a/tests/test_initial_configuration_from_server.rs
+++ b/tests/test_initial_configuration_from_server.rs
@@ -101,7 +101,7 @@ fn server_thread() -> ServerHandle {
 struct MockTokenProvider {}
 
 impl TokenProvider for MockTokenProvider {
-    fn get_access_token(&self) -> appconfiguration::Result<String> {
+    fn get_access_token(&self) -> appconfiguration::NetworkResult<String> {
         Ok("mock_token".into())
     }
 }

--- a/tests/test_ws_connection_fails.rs
+++ b/tests/test_ws_connection_fails.rs
@@ -1,5 +1,5 @@
 use appconfiguration::{
-    AppConfigurationClientHttp, ConfigurationId, Error, ServiceAddress, TokenProvider,
+    AppConfigurationClientHttp, ConfigurationId, NetworkError, ServiceAddress, TokenProvider,
 };
 
 use std::io::{BufRead, BufReader, Write};
@@ -67,7 +67,7 @@ fn server_thread() -> ServerHandle {
 struct MockTokenProvider {}
 
 impl TokenProvider for MockTokenProvider {
-    fn get_access_token(&self) -> appconfiguration::Result<String> {
+    fn get_access_token(&self) -> appconfiguration::NetworkResult<String> {
         Ok("mock_token".into())
     }
 }
@@ -90,5 +90,8 @@ fn main() {
         AppConfigurationClientHttp::new(address, Box::new(MockTokenProvider {}), config_id);
 
     assert!(client.is_err());
-    assert!(matches!(client.unwrap_err(), Error::TungsteniteError(_)));
+    assert!(matches!(
+        client.unwrap_err(),
+        appconfiguration::Error::NetworkError(NetworkError::TungsteniteError(_))
+    ));
 }


### PR DESCRIPTION
Extracted from #60
Working on #63

In this PR we are just introducing new types `NetworkResult` and `NetworkError` that will be used inside the `network` module. Our purpose is to isolate inside this `network` module everything related to outside-world communications and provide a clear (and small) interface that can be reused from the other modules in the crate.