### PR TITLE
feat: Implement offline mode

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2025-04-30T11:38:57Z",
+  "generated_at": "2025-05-05T10:55:39Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -81,7 +81,7 @@
       {
         "hashed_secret": "fb34629c9af1ed4045b5d6f287426276b2be3a1e",
         "is_verified": false,
-        "line_number": 44,
+        "line_number": 46,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/README.md
+++ b/README.md
@@ -31,12 +31,12 @@ Create your client with the context (environment and collection) you want to con
 ```rust
 use appconfiguration::{
     AppConfigurationClient, AppConfigurationClientIBMCloud,
-    ConfigurationId, Entity, Result, Value, Feature
+    ConfigurationId, Entity, Result, Value, Feature, OfflineMode
 };
 
 // Create the client connecting to the server
 let configuration = ConfigurationId::new(guid, environment_id, collection_id);
-let client = AppConfigurationClientIBMCloud::new(&apikey, &region, configuration)?;
+let client = AppConfigurationClientIBMCloud::new(&apikey, &region, configuration, OfflineMode::Fail)?;
 
 // Get the feature you want to evaluate for your entities
 let feature = client.get_feature("AB_testing_feature")?;

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -16,7 +16,7 @@ use std::{collections::HashMap, env, thread, time::Duration};
 
 use appconfiguration::{
     AppConfigurationClient, AppConfigurationClientIBMCloud, ConfigurationId, Entity, Feature,
-    Property, Value,
+    OfflineMode, Property, Value,
 };
 use dotenvy::dotenv;
 use std::error::Error;
@@ -52,7 +52,8 @@ fn main() -> std::result::Result<(), Box<dyn Error>> {
     let property_id = env::var("PROPERTY_ID").expect("PROPERTY_ID should be set.");
 
     let configuration = ConfigurationId::new(guid, environment_id, collection_id);
-    let client = AppConfigurationClientIBMCloud::new(&apikey, &region, configuration)?;
+    let client =
+        AppConfigurationClientIBMCloud::new(&apikey, &region, configuration, OfflineMode::Fail)?;
 
     let entity = CustomerEntity {
         id: "user123".to_string(),

--- a/src/client/app_configuration_http.rs
+++ b/src/client/app_configuration_http.rs
@@ -20,7 +20,7 @@ use crate::errors::Result;
 
 use crate::network::live_configuration::{CurrentMode, LiveConfiguration, LiveConfigurationImpl};
 use crate::network::{ServiceAddress, TokenProvider};
-use crate::ServerClientImpl;
+use crate::{OfflineMode, ServerClientImpl};
 
 use super::{AppConfigurationClient, ConfigurationId};
 
@@ -41,14 +41,17 @@ impl AppConfigurationClientHttp<LiveConfigurationImpl> {
     /// * `service_address` - The address of the server to connect to.
     /// * `token_provider` - An object that can provide the tokens required by the server.
     /// * `configuration_id` - Identifies the App Configuration configuration to use.
+    /// * `offline_mode` - Behavior when the configuration might not be synced with the server
     pub fn new(
         service_address: ServiceAddress,
         token_provider: Box<dyn TokenProvider>,
         configuration_id: ConfigurationId,
+        offline_mode: OfflineMode,
     ) -> Result<Self> {
         let server_client = ServerClientImpl::new(service_address, token_provider)?;
 
-        let live_configuration = LiveConfigurationImpl::new(server_client, configuration_id);
+        let live_configuration =
+            LiveConfigurationImpl::new(offline_mode, server_client, configuration_id);
         Ok(Self { live_configuration })
     }
 }

--- a/src/client/app_configuration_ibm_cloud.rs
+++ b/src/client/app_configuration_ibm_cloud.rs
@@ -19,7 +19,7 @@ use crate::client::property_snapshot::PropertySnapshot;
 use crate::errors::Result;
 use crate::network::live_configuration::LiveConfigurationImpl;
 use crate::network::ServiceAddress;
-use crate::IBMCloudTokenProvider;
+use crate::{IBMCloudTokenProvider, OfflineMode};
 
 use super::AppConfigurationClientHttp;
 use super::{AppConfigurationClient, ConfigurationId};
@@ -41,7 +41,13 @@ impl AppConfigurationClientIBMCloud {
     /// * `apikey` - The encrypted API key.
     /// * `region` - Region name where the App Configuration service instance is created
     /// * `configuration_id` - Identifies the App Configuration configuration to use.
-    pub fn new(apikey: &str, region: &str, configuration_id: ConfigurationId) -> Result<Self> {
+    /// * `offline_mode` - Behavior when the configuration might not be synced with the server
+    pub fn new(
+        apikey: &str,
+        region: &str,
+        configuration_id: ConfigurationId,
+        offline_mode: OfflineMode,
+    ) -> Result<Self> {
         let service_address = Self::create_service_address(region);
         let token_provider = Box::new(IBMCloudTokenProvider::new(apikey));
         Ok(Self {
@@ -49,6 +55,7 @@ impl AppConfigurationClientIBMCloud {
                 service_address,
                 token_provider,
                 configuration_id,
+                offline_mode,
             )?,
         })
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@
 //! ```
 //! use appconfiguration::{
 //!     AppConfigurationClient, AppConfigurationClientIBMCloud,
-//!     ConfigurationId, Entity, Result, Value, Feature
+//!     ConfigurationId, Entity, Result, Value, Feature, OfflineMode
 //! };
 //! # use std::collections::HashMap;
 //! # pub struct MyEntity;
@@ -62,7 +62,7 @@
 //!
 //! // Create the client connecting to the server
 //! let configuration = ConfigurationId::new(guid, environment_id, collection_id);
-//! let client = AppConfigurationClientIBMCloud::new(&apikey, &region, configuration)?;
+//! let client = AppConfigurationClientIBMCloud::new(&apikey, &region, configuration, OfflineMode::Fail)?;
 //!
 //! // Get the feature you want to evaluate for your entities
 //! let feature = client.get_feature("AB_testing_feature")?;
@@ -99,6 +99,7 @@ pub use client::{
 pub use entity::Entity;
 pub use errors::{Error, Result};
 pub use feature::Feature;
+pub use network::live_configuration::OfflineMode;
 pub(crate) use network::{IBMCloudTokenProvider, ServerClientImpl};
 pub use property::Property;
 pub use value::Value;

--- a/src/models.rs
+++ b/src/models.rs
@@ -245,7 +245,7 @@ pub(crate) mod tests {
     }
 
     #[fixture]
-    // Create a [`Configuration`] object from the data files
+    // Creates a [`ConfigurationJson`] object from the data files
     pub(crate) fn example_configuration_enterprise(
         example_configuration_enterprise_path: PathBuf,
     ) -> ConfigurationJson {

--- a/src/network/live_configuration/errors.rs
+++ b/src/network/live_configuration/errors.rs
@@ -33,6 +33,9 @@ pub enum Error {
 
     #[error("{0}")]
     UnrecoverableError(String),
+
+    #[error("Configuration is not yet available (try again later)")]
+    ConfigurationNotYetAvailable,
 }
 
 impl<T> From<PoisonError<T>> for Error {

--- a/src/network/live_configuration/offline_mode.rs
+++ b/src/network/live_configuration/offline_mode.rs
@@ -1,4 +1,4 @@
-// (C) Copyright IBM Corp. 2025.
+// (C) Copyright IBM Corp. 2024.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,13 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod current_mode;
-mod errors;
-mod live_configuration;
-mod offline_mode;
-mod update_thread_worker;
+use crate::AppConfigurationOffline;
 
-pub(crate) use current_mode::CurrentMode;
-pub(crate) use errors::{Error, Result};
-pub use live_configuration::{LiveConfiguration, LiveConfigurationImpl};
-pub use offline_mode::OfflineMode;
+/// Defines the behaviour of the client while the connection to the server
+/// is lost. In all cases the client will keep trying to reconnect forever.
+#[derive(Debug)]
+pub enum OfflineMode {
+    /// Returns errors when requesting features or evaluating them
+    Fail,
+
+    /// Return features and values from the latests configuration available
+    Cache,
+
+    /// Use the provided configuration.
+    FallbackData(AppConfigurationOffline),
+}

--- a/tests/test_initial_configuration_from_server.rs
+++ b/tests/test_initial_configuration_from_server.rs
@@ -1,5 +1,6 @@
 use appconfiguration::{
-    AppConfigurationClient, AppConfigurationClientHttp, ConfigurationId, ServiceAddress,
+    AppConfigurationClient, AppConfigurationClientHttp, ConfigurationId, OfflineMode,
+    ServiceAddress,
 };
 
 use std::net::TcpListener;
@@ -62,9 +63,13 @@ fn main() {
         "dev".to_string(),
         "collection_id".to_string(),
     );
-    let client =
-        AppConfigurationClientHttp::new(address, Box::new(common::MockTokenProvider {}), config_id)
-            .unwrap();
+    let client = AppConfigurationClientHttp::new(
+        address,
+        Box::new(common::MockTokenProvider {}),
+        config_id,
+        OfflineMode::Fail,
+    )
+    .unwrap();
 
     common::wait_until_online(&client);
 

--- a/tests/test_offline_mode.rs
+++ b/tests/test_offline_mode.rs
@@ -1,0 +1,54 @@
+use appconfiguration::{
+    AppConfigurationClient, AppConfigurationClientHttp, AppConfigurationOffline, ConfigurationId,
+    OfflineMode, ServiceAddress,
+};
+
+use std::net::TcpListener;
+
+use std::path::PathBuf;
+
+mod common;
+
+#[test]
+fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
+    // Bind a random port, so we are sure that there is no server there (client will never connect).
+    let server = TcpListener::bind(("127.0.0.1", 0)).expect("Failed to bind");
+    let port = server.local_addr().unwrap().port();
+
+    let client = {
+        // Offline data
+        let mut mocked_data = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        mocked_data.push("data/data-dump-enterprise-plan-sdk-testing.json");
+        let offline_data = AppConfigurationOffline::new(&mocked_data, "dev")?;
+
+        // The actual client
+        let address = ServiceAddress::new_without_ssl(
+            "127.0.0.1".to_string(),
+            Some(port),
+            Some("test".to_string()),
+        );
+        let config_id = ConfigurationId::new(
+            "guid".to_string(),
+            "dev".to_string(),
+            "collection_id".to_string(),
+        );
+
+        AppConfigurationClientHttp::new(
+            address,
+            Box::new(common::MockTokenProvider {}),
+            config_id,
+            OfflineMode::FallbackData(offline_data),
+        )
+        .unwrap()
+    };
+
+    // The client is not online
+    assert!(!client.is_online().unwrap());
+
+    // but it retrieves the fallback data
+    let mut features = client.get_feature_ids().unwrap();
+    features.sort();
+    assert_eq!(features, vec!["f1", "f2", "f3", "f4", "f5", "f6"]);
+
+    Ok(())
+}

--- a/tests/test_ws_connection_close.rs
+++ b/tests/test_ws_connection_close.rs
@@ -1,5 +1,6 @@
 use appconfiguration::{
-    AppConfigurationClient, AppConfigurationClientHttp, ConfigurationId, ServiceAddress,
+    AppConfigurationClient, AppConfigurationClientHttp, ConfigurationId, OfflineMode,
+    ServiceAddress,
 };
 
 use std::net::TcpListener;
@@ -56,9 +57,13 @@ fn main() {
         "dev".to_string(),
         "collection_id".to_string(),
     );
-    let client =
-        AppConfigurationClientHttp::new(address, Box::new(common::MockTokenProvider {}), config_id)
-            .unwrap();
+    let client = AppConfigurationClientHttp::new(
+        address,
+        Box::new(common::MockTokenProvider {}),
+        config_id,
+        OfflineMode::Fail,
+    )
+    .unwrap();
 
     common::wait_until_online(&client);
 


### PR DESCRIPTION
The user can provide offline mode behavior to the http-based clients: `AppConfigurationClientHttp` and `AppConfigurationClientIBMCloud` to control the behavior of the client while it is not connected to the server:
 * `OfflineMode::Fail`: the client will return an error.
 * `OfflineMode::Cache`: the client will return the latest configuration available, if any.
 * `OfflineMode::FallbackData`: the client will use the provided fallback data while it's not connected to the server.

closes #63 (implements the feature)
closes #60 (PR is superseeded)