### PR TITLE
chore: Run pre-commit in PRs (all files)

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -15,3 +15,4 @@ jobs:
         run: |
           pip install pre-commit
           pre-commit run -a
+          git diff

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -14,5 +14,4 @@ jobs:
       - name: Run pre-commit
         run: |
           pip install pre-commit
-          pre-commit run -a
-          git diff
+          pre-commit run -a --show-diff-on-failure

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,17 @@
+name: pre-commit
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+      - name: Run pre-commit
+        run: |
+          pip install pre-commit
+          pre-commit run -a

--- a/src/segment_evaluation/mod.rs
+++ b/src/segment_evaluation/mod.rs
@@ -58,16 +58,18 @@ impl SegmentRules {
         entity: &impl Entity,
     ) -> Result<Option<(SegmentRule, &Segment)>> {
         for targeting_rule in self.targeting_rules.iter() {
-            if let Some(segment) = find_segment_of_targeting_rule_which_applies_to_entity(&self.segments, targeting_rule, entity)? {
-                return Ok(Some(
-                    (
+            if let Some(segment) = find_segment_of_targeting_rule_which_applies_to_entity(
+                &self.segments,
+                targeting_rule,
+                entity,
+            )? {
+                return Ok(Some((
                     SegmentRule {
                         targeting_rule,
                         kind: self.kind,
                     },
-                    segment
-                    )
-                ));
+                    segment,
+                )));
             }
         }
         Ok(None)
@@ -139,7 +141,11 @@ fn find_segment_of_targeting_rule_which_applies_to_entity<'a>(
     // NOTE: In the JSON model the targeted segments (list of list) are called "rules" of a targeting rule.
     let targeted_segment_list_of_list = &targeting_rule.rules;
     for targeted_segment_list in targeted_segment_list_of_list.iter() {
-        return Ok(find_segment_which_applies_to_entity(segments, &targeted_segment_list.segments, entity)?);
+        return Ok(find_segment_which_applies_to_entity(
+            segments,
+            &targeted_segment_list.segments,
+            entity,
+        )?);
     }
     Ok(None)
 }
@@ -270,34 +276,34 @@ pub mod tests {
     #[fixture]
     fn segments() -> HashMap<String, Segment> {
         HashMap::from([
-        (
-            "some_segment_id_1".into(),
-            Segment {
-                _name: "".into(),
-                segment_id: "some_segment_id_1".into(),
-                _description: "".into(),
-                _tags: None,
-                rules: vec![SegmentRule {
-                    attribute_name: "name".into(),
-                    operator: "is".into(),
-                    values: vec!["heinz".into()],
-                }],
-            },
-        ),
-        (
-            "some_segment_id_2".into(),
-            Segment {
-                _name: "".into(),
-                segment_id: "some_segment_id_2".into(),
-                _description: "".into(),
-                _tags: None,
-                rules: vec![SegmentRule {
-                    attribute_name: "name".into(),
-                    operator: "is".into(),
-                    values: vec!["peter".into()],
-                }],
-            },
-        )
+            (
+                "some_segment_id_1".into(),
+                Segment {
+                    _name: "".into(),
+                    segment_id: "some_segment_id_1".into(),
+                    _description: "".into(),
+                    _tags: None,
+                    rules: vec![SegmentRule {
+                        attribute_name: "name".into(),
+                        operator: "is".into(),
+                        values: vec!["heinz".into()],
+                    }],
+                },
+            ),
+            (
+                "some_segment_id_2".into(),
+                Segment {
+                    _name: "".into(),
+                    segment_id: "some_segment_id_2".into(),
+                    _description: "".into(),
+                    _tags: None,
+                    rules: vec![SegmentRule {
+                        attribute_name: "name".into(),
+                        operator: "is".into(),
+                        values: vec!["peter".into()],
+                    }],
+                },
+            ),
         ])
     }
 
@@ -305,7 +311,7 @@ pub mod tests {
     fn targeting_rules() -> Vec<TargetingRule> {
         vec![TargetingRule {
             rules: vec![Segments {
-                segments: vec!["some_segment_id_1".into(),"some_segment_id_2".into()],
+                segments: vec!["some_segment_id_1".into(), "some_segment_id_2".into()],
             }],
             value: ConfigValue(serde_json::Value::Number((-48).into())),
             order: 0,
@@ -390,7 +396,10 @@ pub mod tests {
     // SCENARIO - evaluating an operator fails. Meaning, [for example] user has added a numeric value(int/float) in appconfig segment attribute, but in their application they pass the attribute with a boolean value.
     // We can mark this as failure and return error.
     #[rstest]
-    fn test_operator_failed(segments: HashMap<String, Segment>, targeting_rules: Vec<TargetingRule>) {
+    fn test_operator_failed(
+        segments: HashMap<String, Segment>,
+        targeting_rules: Vec<TargetingRule>,
+    ) {
         let segment_rules = SegmentRules::new(segments, targeting_rules, ValueKind::String);
         let entity = crate::tests::GenericEntity {
             id: "a2".into(),


### PR DESCRIPTION
Create another github workflow to run pre-commit hooks in all PRs.

 * I'm running all pre-commits in all the files regardless of the files impacted in the PR. Our crate is small, we don't have too many files (we pay the price of cloning the repo one more time, though)
 * I'm using a different workflow because I only want pre-commits to run in pull-requests. We don't want to fail in `main` because of them.