### PR TITLE
chore: Renames associated to `SegmentRule` and `TargetingRule`

### DIFF
--- a/src/client/configuration.rs
+++ b/src/client/configuration.rs
@@ -65,7 +65,7 @@ impl Configuration {
                 }
 
                 let segment_rules =
-                    SegmentRules::new(segments, feature.segment_rules.clone(), feature.kind);
+                    SegmentRules::new(segments, feature.segment_rules.clone(), feature.r#type);
 
                 Ok((feature.feature_id.clone(), (feature, segment_rules)))
             })
@@ -92,7 +92,7 @@ impl Configuration {
                 }
 
                 let segment_rules =
-                    SegmentRules::new(segments, property.segment_rules.clone(), property.kind);
+                    SegmentRules::new(segments, property.segment_rules.clone(), property.r#type);
                 Ok((property.property_id.clone(), (property, segment_rules)))
             })
             .collect::<Result<_>>()?;
@@ -149,8 +149,8 @@ impl ConfigurationProvider for Configuration {
             })
         })?;
 
-        let enabled_value = (feature.kind, feature.enabled_value.clone()).try_into()?;
-        let disabled_value = (feature.kind, feature.disabled_value.clone()).try_into()?;
+        let enabled_value = (feature.r#type, feature.enabled_value.clone()).try_into()?;
+        let disabled_value = (feature.r#type, feature.disabled_value.clone()).try_into()?;
         Ok(FeatureSnapshot::new(
             feature.enabled,
             enabled_value,
@@ -174,7 +174,7 @@ impl ConfigurationProvider for Configuration {
             })
         })?;
 
-        let value = (property.kind, property.value.clone()).try_into()?;
+        let value = (property.r#type, property.value.clone()).try_into()?;
         Ok(PropertySnapshot::new(
             value,
             segment_rules.clone(),

--- a/src/client/configuration.rs
+++ b/src/client/configuration.rs
@@ -15,8 +15,8 @@
 use std::collections::{HashMap, HashSet};
 
 use crate::errors::{ConfigurationAccessError, Result};
-use crate::models::{ConfigurationJson, Feature, Property, Segment, TargetingRule};
-use crate::segment_evaluation::SegmentRules;
+use crate::models::{ConfigurationJson, Feature, Property, Segment, SegmentRule};
+use crate::segment_evaluation::TargetingRules;
 use crate::Error;
 
 use super::feature_snapshot::FeatureSnapshot;
@@ -28,8 +28,8 @@ use super::ConfigurationProvider;
 /// It contains a subset of models::ConfigurationJson, adding indexing.
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct Configuration {
-    pub(crate) features: HashMap<String, (Feature, SegmentRules)>,
-    pub(crate) properties: HashMap<String, (Property, SegmentRules)>,
+    pub(crate) features: HashMap<String, (Feature, TargetingRules)>,
+    pub(crate) properties: HashMap<String, (Property, TargetingRules)>,
 }
 
 impl Configuration {
@@ -65,7 +65,7 @@ impl Configuration {
                 }
 
                 let segment_rules =
-                    SegmentRules::new(segments, feature.segment_rules.clone(), feature.r#type);
+                    TargetingRules::new(segments, feature.segment_rules.clone(), feature.r#type);
 
                 Ok((feature.feature_id.clone(), (feature, segment_rules)))
             })
@@ -92,7 +92,7 @@ impl Configuration {
                 }
 
                 let segment_rules =
-                    SegmentRules::new(segments, property.segment_rules.clone(), property.r#type);
+                    TargetingRules::new(segments, property.segment_rules.clone(), property.r#type);
                 Ok((property.property_id.clone(), (property, segment_rules)))
             })
             .collect::<Result<_>>()?;
@@ -107,7 +107,7 @@ impl Configuration {
     /// by the given `segment_rules`.
     fn get_segments_for_segment_rules(
         segments: &[Segment],
-        segment_rules: &[TargetingRule],
+        segment_rules: &[SegmentRule],
     ) -> HashMap<String, Segment> {
         let referenced_segment_ids = segment_rules
             .iter()

--- a/src/client/feature_snapshot.rs
+++ b/src/client/feature_snapshot.rs
@@ -135,7 +135,7 @@ impl Feature for FeatureSnapshot {
 pub mod tests {
 
     use super::*;
-    use crate::models::{ConfigValue, Segment, SegmentRule, Segments, TargetingRule, ValueKind};
+    use crate::models::{ConfigValue, Segment, SegmentRule, Segments, TargetingRule, ValueType};
     use rstest::rstest;
     use std::collections::HashMap;
 
@@ -176,7 +176,7 @@ pub mod tests {
     ) {
         let feature = {
             let segment_rules =
-                SegmentRules::new(HashMap::new(), segment_rules, ValueKind::Numeric);
+                SegmentRules::new(HashMap::new(), segment_rules, ValueType::Numeric);
             FeatureSnapshot::new(
                 true,
                 Value::Int64(-42),
@@ -217,7 +217,7 @@ pub mod tests {
     #[test]
     fn test_get_value_disabled_feature() {
         let feature = {
-            let segment_rules = SegmentRules::new(HashMap::new(), Vec::new(), ValueKind::Numeric);
+            let segment_rules = SegmentRules::new(HashMap::new(), Vec::new(), ValueType::Numeric);
             FeatureSnapshot::new(
                 false,
                 Value::Int64(-42),
@@ -242,10 +242,10 @@ pub mod tests {
             let segments = HashMap::from([(
                 "some_segment_id".into(),
                 Segment {
-                    _name: "".into(),
+                    name: "".into(),
                     segment_id: "".into(),
-                    _description: "".into(),
-                    _tags: None,
+                    description: "".into(),
+                    tags: None,
                     rules: vec![SegmentRule {
                         attribute_name: "name".into(),
                         operator: "is".into(),
@@ -263,7 +263,7 @@ pub mod tests {
                     order: 0,
                     rollout_percentage: Some(ConfigValue(serde_json::Value::Number((50).into()))),
                 }],
-                ValueKind::Numeric,
+                ValueType::Numeric,
             );
             FeatureSnapshot::new(
                 true,
@@ -312,10 +312,10 @@ pub mod tests {
             let segments = HashMap::from([(
                 "some_segment_id".into(),
                 Segment {
-                    _name: "".into(),
+                    name: "".into(),
                     segment_id: "".into(),
-                    _description: "".into(),
-                    _tags: None,
+                    description: "".into(),
+                    tags: None,
                     rules: vec![SegmentRule {
                         attribute_name: "name".into(),
                         operator: "is".into(),
@@ -333,7 +333,7 @@ pub mod tests {
                     order: 0,
                     rollout_percentage: Some(ConfigValue(serde_json::Value::Number((50).into()))),
                 }],
-                ValueKind::Numeric,
+                ValueType::Numeric,
             );
             FeatureSnapshot::new(
                 true,
@@ -364,10 +364,10 @@ pub mod tests {
             let segments = HashMap::from([(
                 "some_segment_id".into(),
                 Segment {
-                    _name: "".into(),
+                    name: "".into(),
                     segment_id: "".into(),
-                    _description: "".into(),
-                    _tags: None,
+                    description: "".into(),
+                    tags: None,
                     rules: vec![SegmentRule {
                         attribute_name: "name".into(),
                         operator: "is".into(),
@@ -387,7 +387,7 @@ pub mod tests {
                         "$default".into(),
                     ))),
                 }],
-                ValueKind::Numeric,
+                ValueType::Numeric,
             );
             FeatureSnapshot::new(
                 true,

--- a/src/client/feature_snapshot.rs
+++ b/src/client/feature_snapshot.rs
@@ -135,7 +135,7 @@ impl Feature for FeatureSnapshot {
 pub mod tests {
 
     use super::*;
-    use crate::models::{ConfigValue, Segment, SegmentRule, Segments, TargetingRule, ValueType};
+    use crate::models::{ConfigValue, Rule, Segment, Segments, TargetingRule, ValueType};
     use rstest::rstest;
     use std::collections::HashMap;
 
@@ -246,7 +246,7 @@ pub mod tests {
                     segment_id: "".into(),
                     description: "".into(),
                     tags: None,
-                    rules: vec![SegmentRule {
+                    rules: vec![Rule {
                         attribute_name: "name".into(),
                         operator: "is".into(),
                         values: vec!["heinz".into()],
@@ -316,7 +316,7 @@ pub mod tests {
                     segment_id: "".into(),
                     description: "".into(),
                     tags: None,
-                    rules: vec![SegmentRule {
+                    rules: vec![Rule {
                         attribute_name: "name".into(),
                         operator: "is".into(),
                         values: vec!["heinz".into()],
@@ -368,7 +368,7 @@ pub mod tests {
                     segment_id: "".into(),
                     description: "".into(),
                     tags: None,
-                    rules: vec![SegmentRule {
+                    rules: vec![Rule {
                         attribute_name: "name".into(),
                         operator: "is".into(),
                         values: vec!["heinz".into()],

--- a/src/client/feature_snapshot.rs
+++ b/src/client/feature_snapshot.rs
@@ -17,7 +17,7 @@ use crate::value::Value;
 use crate::Feature;
 
 use super::feature_proxy::random_value;
-use crate::segment_evaluation::SegmentRules;
+use crate::segment_evaluation::TargetingRules;
 
 use crate::errors::Result;
 
@@ -30,7 +30,7 @@ pub struct FeatureSnapshot {
     rollout_percentage: u32,
     name: String,
     feature_id: String,
-    segment_rules: SegmentRules,
+    segment_rules: TargetingRules,
 }
 
 impl FeatureSnapshot {
@@ -41,7 +41,7 @@ impl FeatureSnapshot {
         rollout_percentage: u32,
         name: &str,
         feature_id: &str,
-        segment_rules: SegmentRules,
+        segment_rules: TargetingRules,
     ) -> Self {
         Self {
             enabled,
@@ -135,7 +135,7 @@ impl Feature for FeatureSnapshot {
 pub mod tests {
 
     use super::*;
-    use crate::models::{ConfigValue, Rule, Segment, Segments, TargetingRule, ValueType};
+    use crate::models::{ConfigValue, Rule, Segment, SegmentRule, Segments, ValueType};
     use rstest::rstest;
     use std::collections::HashMap;
 
@@ -169,14 +169,14 @@ pub mod tests {
     // attrs but no segment rules
     #[case([].into(), [("key".into(), Value::from("value".to_string()))].into())]
     // no attrs but segment rules
-    #[case([TargetingRule{rules: Vec::new(), value: ConfigValue(serde_json::json!("")), order: 0, rollout_percentage: None}].into(), [].into())]
+    #[case([SegmentRule{rules: Vec::new(), value: ConfigValue(serde_json::json!("")), order: 0, rollout_percentage: None}].into(), [].into())]
     fn test_get_value_no_match_50_50_rollout(
-        #[case] segment_rules: Vec<TargetingRule>,
+        #[case] segment_rules: Vec<SegmentRule>,
         #[case] entity_attributes: HashMap<String, Value>,
     ) {
         let feature = {
             let segment_rules =
-                SegmentRules::new(HashMap::new(), segment_rules, ValueType::Numeric);
+                TargetingRules::new(HashMap::new(), segment_rules, ValueType::Numeric);
             FeatureSnapshot::new(
                 true,
                 Value::Int64(-42),
@@ -217,7 +217,7 @@ pub mod tests {
     #[test]
     fn test_get_value_disabled_feature() {
         let feature = {
-            let segment_rules = SegmentRules::new(HashMap::new(), Vec::new(), ValueType::Numeric);
+            let segment_rules = TargetingRules::new(HashMap::new(), Vec::new(), ValueType::Numeric);
             FeatureSnapshot::new(
                 false,
                 Value::Int64(-42),
@@ -253,9 +253,9 @@ pub mod tests {
                     }],
                 },
             )]);
-            let segment_rules = SegmentRules::new(
+            let segment_rules = TargetingRules::new(
                 segments,
-                vec![TargetingRule {
+                vec![SegmentRule {
                     rules: vec![Segments {
                         segments: vec!["some_segment_id".into()],
                     }],
@@ -323,9 +323,9 @@ pub mod tests {
                     }],
                 },
             )]);
-            let segment_rules = SegmentRules::new(
+            let segment_rules = TargetingRules::new(
                 segments,
-                vec![TargetingRule {
+                vec![SegmentRule {
                     rules: vec![Segments {
                         segments: vec!["some_segment_id".into()],
                     }],
@@ -375,9 +375,9 @@ pub mod tests {
                     }],
                 },
             )]);
-            let segment_rules = SegmentRules::new(
+            let segment_rules = TargetingRules::new(
                 segments,
-                vec![TargetingRule {
+                vec![SegmentRule {
                     rules: vec![Segments {
                         segments: vec!["some_segment_id".into()],
                     }],

--- a/src/client/property_snapshot.rs
+++ b/src/client/property_snapshot.rs
@@ -83,7 +83,7 @@ impl Property for PropertySnapshot {
 pub mod tests {
 
     use super::*;
-    use crate::models::{ConfigValue, Segment, SegmentRule, Segments, TargetingRule, ValueKind};
+    use crate::models::{ConfigValue, Segment, SegmentRule, Segments, TargetingRule, ValueType};
     use std::collections::HashMap;
 
     #[test]
@@ -92,10 +92,10 @@ pub mod tests {
             let segments = HashMap::from([(
                 "some_segment_id_1".into(),
                 Segment {
-                    _name: "".into(),
+                    name: "".into(),
                     segment_id: "".into(),
-                    _description: "".into(),
-                    _tags: None,
+                    description: "".into(),
+                    tags: None,
                     rules: vec![SegmentRule {
                         attribute_name: "name".into(),
                         operator: "is".into(),
@@ -113,7 +113,7 @@ pub mod tests {
                     order: 1,
                     rollout_percentage: Some(ConfigValue(serde_json::Value::Number((100).into()))),
                 }],
-                ValueKind::Numeric,
+                ValueType::Numeric,
             );
             PropertySnapshot::new(Value::Int64(-42), segment_rules, "F1")
         };

--- a/src/client/property_snapshot.rs
+++ b/src/client/property_snapshot.rs
@@ -17,18 +17,18 @@ use crate::value::Value;
 use crate::Property;
 
 use crate::errors::Result;
-use crate::segment_evaluation::SegmentRules;
+use crate::segment_evaluation::TargetingRules;
 
 /// Provides a snapshot of a [`Property`].
 #[derive(Debug)]
 pub struct PropertySnapshot {
     value: Value,
-    segment_rules: SegmentRules,
+    segment_rules: TargetingRules,
     name: String,
 }
 
 impl PropertySnapshot {
-    pub(crate) fn new(value: Value, segment_rules: SegmentRules, name: &str) -> Self {
+    pub(crate) fn new(value: Value, segment_rules: TargetingRules, name: &str) -> Self {
         Self {
             value,
             segment_rules,
@@ -83,7 +83,7 @@ impl Property for PropertySnapshot {
 pub mod tests {
 
     use super::*;
-    use crate::models::{ConfigValue, Rule, Segment, Segments, TargetingRule, ValueType};
+    use crate::models::{ConfigValue, Rule, Segment, SegmentRule, Segments, ValueType};
     use std::collections::HashMap;
 
     #[test]
@@ -103,9 +103,9 @@ pub mod tests {
                     }],
                 },
             )]);
-            let segment_rules = SegmentRules::new(
+            let segment_rules = TargetingRules::new(
                 segments,
-                vec![TargetingRule {
+                vec![SegmentRule {
                     rules: vec![Segments {
                         segments: vec!["some_segment_id_1".into()],
                     }],

--- a/src/client/property_snapshot.rs
+++ b/src/client/property_snapshot.rs
@@ -83,7 +83,7 @@ impl Property for PropertySnapshot {
 pub mod tests {
 
     use super::*;
-    use crate::models::{ConfigValue, Segment, SegmentRule, Segments, TargetingRule, ValueType};
+    use crate::models::{ConfigValue, Rule, Segment, Segments, TargetingRule, ValueType};
     use std::collections::HashMap;
 
     #[test]
@@ -96,7 +96,7 @@ pub mod tests {
                     segment_id: "".into(),
                     description: "".into(),
                     tags: None,
-                    rules: vec![SegmentRule {
+                    rules: vec![Rule {
                         attribute_name: "name".into(),
                         operator: "is".into(),
                         values: vec!["heinz".into()],

--- a/src/models.rs
+++ b/src/models.rs
@@ -76,8 +76,6 @@ pub struct Feature {
     pub format: Option<String>,
     pub enabled_value: ConfigValue,
     pub disabled_value: ConfigValue,
-    // NOTE: why is this field called `segment_rules` and not `targeting_rules`?
-    // This causes quite som ambiguity with SegmentRule vs TargetingRule.
     pub segment_rules: Vec<SegmentRule>,
     pub enabled: bool,
     pub rollout_percentage: u32,
@@ -91,8 +89,6 @@ pub struct Property {
     pub tags: Option<String>,
     pub format: Option<String>,
     pub value: ConfigValue,
-    // NOTE: why is this field called `segment_rules` and not `targeting_rules`?
-    // This causes quite som ambiguity with SegmentRule vs TargetingRule.
     pub segment_rules: Vec<SegmentRule>,
 }
 
@@ -189,8 +185,6 @@ impl TryFrom<(ValueType, ConfigValue)> for Value {
 
 /// Represents a Rule of a Segment.
 /// Those are the rules to check if an entity belongs to a segment.
-/// NOTE: This is easily confused with `TargetingRule`, which is
-/// sometimes also called "SegmentRule".
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
 pub struct Rule {
     pub attribute_name: String,
@@ -199,8 +193,6 @@ pub struct Rule {
 }
 
 /// Associates a Feature/Property to one or more Segments
-/// NOTE: This is easily confused with `SegmentRule`, as the field name in
-/// Features containing TargetingRules is called `segment_rules`
 #[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
 pub struct SegmentRule {
     /// The list of targeted segments

--- a/src/models.rs
+++ b/src/models.rs
@@ -65,7 +65,7 @@ pub struct Segment {
     pub segment_id: String,
     pub description: String,
     pub tags: Option<String>,
-    pub rules: Vec<SegmentRule>,
+    pub rules: Vec<Rule>,
 }
 
 #[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
@@ -192,7 +192,7 @@ impl TryFrom<(ValueType, ConfigValue)> for Value {
 /// NOTE: This is easily confused with `TargetingRule`, which is
 /// sometimes also called "SegmentRule".
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
-pub struct SegmentRule {
+pub struct Rule {
     pub attribute_name: String,
     pub operator: String,
     pub values: Vec<String>,
@@ -340,7 +340,7 @@ pub(crate) mod tests {
                     segment_id: "some_segment_id_1".into(),
                     description: "".into(),
                     tags: None,
-                    rules: vec![SegmentRule {
+                    rules: vec![Rule {
                         attribute_name: "name".into(),
                         operator: "is".into(),
                         values: vec!["heinz".into()],
@@ -351,7 +351,7 @@ pub(crate) mod tests {
                     segment_id: "some_segment_id_2".into(),
                     description: "".into(),
                     tags: None,
-                    rules: vec![SegmentRule {
+                    rules: vec![Rule {
                         attribute_name: "name".into(),
                         operator: "is".into(),
                         values: vec!["heinz".into()],

--- a/src/models.rs
+++ b/src/models.rs
@@ -78,7 +78,7 @@ pub struct Feature {
     pub disabled_value: ConfigValue,
     // NOTE: why is this field called `segment_rules` and not `targeting_rules`?
     // This causes quite som ambiguity with SegmentRule vs TargetingRule.
-    pub segment_rules: Vec<TargetingRule>,
+    pub segment_rules: Vec<SegmentRule>,
     pub enabled: bool,
     pub rollout_percentage: u32,
 }
@@ -93,7 +93,7 @@ pub struct Property {
     pub value: ConfigValue,
     // NOTE: why is this field called `segment_rules` and not `targeting_rules`?
     // This causes quite som ambiguity with SegmentRule vs TargetingRule.
-    pub segment_rules: Vec<TargetingRule>,
+    pub segment_rules: Vec<SegmentRule>,
 }
 
 #[derive(Copy, Clone, Debug, Deserialize, PartialEq, Eq)]
@@ -202,7 +202,7 @@ pub struct Rule {
 /// NOTE: This is easily confused with `SegmentRule`, as the field name in
 /// Features containing TargetingRules is called `segment_rules`
 #[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
-pub struct TargetingRule {
+pub struct SegmentRule {
     /// The list of targeted segments
     /// NOTE: no rules by itself, but the rules are found in the segments
     /// NOTE: why list of lists?
@@ -291,7 +291,7 @@ pub(crate) mod tests {
     #[fixture]
     pub(crate) fn configuration_unordered_segment_rules() -> ConfigurationJson {
         let segment_rules = vec![
-            TargetingRule {
+            SegmentRule {
                 rules: vec![Segments {
                     segments: vec!["some_segment_id_1".into()],
                 }],
@@ -299,7 +299,7 @@ pub(crate) mod tests {
                 order: 1,
                 rollout_percentage: Some(ConfigValue(serde_json::Value::Number((100).into()))),
             },
-            TargetingRule {
+            SegmentRule {
                 rules: vec![Segments {
                     segments: vec!["some_segment_id_2".into()],
                 }],

--- a/src/segment_evaluation/errors.rs
+++ b/src/segment_evaluation/errors.rs
@@ -14,7 +14,7 @@
 
 use thiserror::Error;
 
-use crate::models::{Segment, SegmentRule};
+use crate::models::{Rule, Segment};
 
 #[derive(Debug, Error)]
 pub(crate) enum SegmentEvaluationError {
@@ -41,8 +41,8 @@ pub(crate) struct SegmentEvaluationErrorKind {
     pub(crate) source: CheckOperatorErrorDetail,
 }
 
-impl From<(CheckOperatorErrorDetail, &Segment, &SegmentRule, &String)> for SegmentEvaluationError {
-    fn from(value: (CheckOperatorErrorDetail, &Segment, &SegmentRule, &String)) -> Self {
+impl From<(CheckOperatorErrorDetail, &Segment, &Rule, &String)> for SegmentEvaluationError {
+    fn from(value: (CheckOperatorErrorDetail, &Segment, &Rule, &String)) -> Self {
         let (source, segment, segment_rule, value) = value;
         Self::SegmentEvaluationFailed(SegmentEvaluationErrorKind {
             segment_id: segment.segment_id.clone(),

--- a/src/segment_evaluation/mod.rs
+++ b/src/segment_evaluation/mod.rs
@@ -32,7 +32,6 @@ pub(crate) struct TargetingRules {
     r#type: ValueType,
 }
 
-// TODO: We should rename this to TargetingRules
 impl TargetingRules {
     pub(crate) fn new(
         segments: HashMap<String, Segment>,
@@ -50,8 +49,8 @@ impl TargetingRules {
         self.segment_rules.is_empty()
     }
 
-    /// Finds the targeting rule (aka SegmentRule) and the Segment which a given entity can be associated to.
-    /// Note: A feature/property can have multiple TargetingRules (aka SegmentRules), which define a specific feature/property value. One SegmentRule/TargetingRule can point to multiple Segments. Rules and Segments are iterated in order and the first match is reported.
+    /// Finds the [`TargetingRule`] and the [`Segment`] which a given entity can be associated to.
+    /// Note: A feature/property can have multiple TargetingRules, which define a specific feature/property value. One TargetingRule can point to multiple Segments. Rules and Segments are iterated in order and the first match is reported.
     /// TODO: A TargetingRule can have Rules and Segments also have Rules. Those are easily confused. Especially, as TargetingRules are sometimes referred to as SegmentRules, which causes even greater confusion.
     pub(crate) fn find_applicable_targeting_rule_and_segment_for_entity(
         &self,
@@ -76,8 +75,6 @@ impl TargetingRules {
     }
 }
 
-// TODO: We should rename this to TargetingRule, it is basically encapsulation one.
-// (need to avoid conflict with models::TargetingRule)
 #[derive(Debug)]
 pub(crate) struct TargetingRule<'a> {
     segment_rule: &'a SegmentRule,

--- a/src/segment_evaluation/mod.rs
+++ b/src/segment_evaluation/mod.rs
@@ -21,7 +21,7 @@ use crate::errors::Error;
 use crate::errors::Result;
 use crate::models::Segment;
 use crate::models::TargetingRule;
-use crate::models::ValueKind;
+use crate::models::ValueType;
 use crate::Value;
 use errors::{CheckOperatorErrorDetail, SegmentEvaluationError};
 
@@ -29,7 +29,7 @@ use errors::{CheckOperatorErrorDetail, SegmentEvaluationError};
 pub(crate) struct SegmentRules {
     targeting_rules: Vec<TargetingRule>,
     segments: HashMap<String, Segment>,
-    kind: ValueKind,
+    kind: ValueType,
 }
 
 // TODO: We should rename this to TargetingRules
@@ -37,7 +37,7 @@ impl SegmentRules {
     pub(crate) fn new(
         segments: HashMap<String, Segment>,
         targeting_rules: Vec<TargetingRule>,
-        kind: ValueKind,
+        kind: ValueType,
     ) -> Self {
         Self {
             segments,
@@ -81,7 +81,7 @@ impl SegmentRules {
 #[derive(Debug)]
 pub(crate) struct SegmentRule<'a> {
     targeting_rule: &'a TargetingRule,
-    kind: ValueKind,
+    kind: ValueType,
 }
 
 impl SegmentRule<'_> {
@@ -280,10 +280,10 @@ pub mod tests {
             (
                 "some_segment_id_1".into(),
                 Segment {
-                    _name: "".into(),
+                    name: "".into(),
                     segment_id: "some_segment_id_1".into(),
-                    _description: "".into(),
-                    _tags: None,
+                    description: "".into(),
+                    tags: None,
                     rules: vec![SegmentRule {
                         attribute_name: "name".into(),
                         operator: "is".into(),
@@ -294,10 +294,10 @@ pub mod tests {
             (
                 "some_segment_id_2".into(),
                 Segment {
-                    _name: "".into(),
+                    name: "".into(),
                     segment_id: "some_segment_id_2".into(),
-                    _description: "".into(),
-                    _tags: None,
+                    description: "".into(),
+                    tags: None,
                     rules: vec![SegmentRule {
                         attribute_name: "name".into(),
                         operator: "is".into(),
@@ -308,10 +308,10 @@ pub mod tests {
             (
                 "some_segment_id_3".into(),
                 Segment {
-                    _name: "".into(),
+                    name: "".into(),
                     segment_id: "some_segment_id_3".into(),
-                    _description: "".into(),
-                    _tags: None,
+                    description: "".into(),
+                    tags: None,
                     rules: vec![SegmentRule {
                         attribute_name: "name".into(),
                         operator: "is".into(),
@@ -344,7 +344,7 @@ pub mod tests {
         segments: HashMap<String, Segment>,
         targeting_rules: Vec<TargetingRule>,
     ) {
-        let segment_rules = SegmentRules::new(segments, targeting_rules, ValueKind::String);
+        let segment_rules = SegmentRules::new(segments, targeting_rules, ValueType::String);
         let entity = crate::tests::GenericEntity {
             id: "a2".into(),
             attributes: HashMap::from([("name".into(), Value::from("peter".to_string()))]),
@@ -391,7 +391,7 @@ pub mod tests {
         segments: HashMap<String, Segment>,
         targeting_rules: Vec<TargetingRule>,
     ) {
-        let segment_rules = SegmentRules::new(segments, targeting_rules, ValueKind::String);
+        let segment_rules = SegmentRules::new(segments, targeting_rules, ValueType::String);
         let entity = crate::tests::GenericEntity {
             id: "a2".into(),
             attributes: HashMap::from([("name2".into(), Value::from("heinz".to_string()))]),
@@ -421,7 +421,7 @@ pub mod tests {
                 order: 0,
                 rollout_percentage: Some(ConfigValue(serde_json::Value::Number((100).into()))),
             }];
-            SegmentRules::new(segments, targeting_rules, ValueKind::String)
+            SegmentRules::new(segments, targeting_rules, ValueType::String)
         };
         let rule = segment_rules.find_applicable_targeting_rule_and_segment_for_entity(&entity);
         // Error message should look something like this:
@@ -446,7 +446,7 @@ pub mod tests {
         segments: HashMap<String, Segment>,
         targeting_rules: Vec<TargetingRule>,
     ) {
-        let segment_rules = SegmentRules::new(segments, targeting_rules, ValueKind::String);
+        let segment_rules = SegmentRules::new(segments, targeting_rules, ValueType::String);
         let entity = crate::tests::GenericEntity {
             id: "a2".into(),
             attributes: HashMap::from([("name".into(), Value::from(42.0))]),

--- a/src/segment_evaluation/mod.rs
+++ b/src/segment_evaluation/mod.rs
@@ -271,7 +271,7 @@ fn check_operator(
 pub mod tests {
     use super::*;
     use crate::errors::{EntityEvaluationError, Error};
-    use crate::models::{ConfigValue, Segment, SegmentRule, Segments, TargetingRule};
+    use crate::models::{ConfigValue, Rule, Segment, Segments, TargetingRule};
     use rstest::*;
 
     #[fixture]
@@ -284,7 +284,7 @@ pub mod tests {
                     segment_id: "some_segment_id_1".into(),
                     description: "".into(),
                     tags: None,
-                    rules: vec![SegmentRule {
+                    rules: vec![Rule {
                         attribute_name: "name".into(),
                         operator: "is".into(),
                         values: vec!["heinz".into()],
@@ -298,7 +298,7 @@ pub mod tests {
                     segment_id: "some_segment_id_2".into(),
                     description: "".into(),
                     tags: None,
-                    rules: vec![SegmentRule {
+                    rules: vec![Rule {
                         attribute_name: "name".into(),
                         operator: "is".into(),
                         values: vec!["peter".into()],
@@ -312,7 +312,7 @@ pub mod tests {
                     segment_id: "some_segment_id_3".into(),
                     description: "".into(),
                     tags: None,
-                    rules: vec![SegmentRule {
+                    rules: vec![Rule {
                         attribute_name: "name".into(),
                         operator: "is".into(),
                         values: vec!["jane".into()],


### PR DESCRIPTION
* For the JSON fields (`appconfiguration::models`): the name in Rust matches the name in the JSON. There is no need to rename, the more they look like each other, the easier it will be to understand. We can (should) document them a little bit, but they will be _private_ (🤞 ), so it should be internal documentation only.
* In the `segment_evaluation` module, I changed the names to `TargetingRule`, as suggested by @rainerschoe is previous comments. Better documentation is still pending.