### PR TITLE
refact: Hide `AppConfigurationClientHttp` (and others) from the user 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ exclude = [
 ]
 
 [features]
-http_client = []
+test_utils = []
 
 [dependencies]
 reqwest = { version = "0.12.9", features = ["json", "blocking"] }
@@ -31,7 +31,7 @@ url = "2.5.4"
 thiserror = "2.0.7"
 
 [dev-dependencies]
-appconfiguration = {path = ".", features = ["http_client"]}
+appconfiguration = {path = ".", features = ["test_utils"]}
 dotenvy = "0.15.7"
 rstest = "0.25.0"
 

--- a/src/client/app_configuration_client.rs
+++ b/src/client/app_configuration_client.rs
@@ -64,6 +64,10 @@ pub trait ConfigurationProvider {
     /// will always evaluate the same entities to the same values, no updates
     /// will be received from the server
     fn get_property(&self, property_id: &str) -> Result<PropertySnapshot>;
+
+    /// For remote configurations, it returns whether it's connected to the
+    /// remote or not
+    fn is_online(&self) -> Result<bool>;
 }
 
 /// AppConfiguration client for browsing, and evaluating features and properties.

--- a/src/client/app_configuration_http.rs
+++ b/src/client/app_configuration_http.rs
@@ -16,7 +16,7 @@ use crate::client::feature_snapshot::FeatureSnapshot;
 use crate::client::property_snapshot::PropertySnapshot;
 use crate::errors::Result;
 
-use crate::network::live_configuration::{CurrentMode, LiveConfiguration, LiveConfigurationImpl};
+use crate::network::live_configuration::{LiveConfiguration, LiveConfigurationImpl};
 use crate::network::{ServiceAddress, TokenProvider};
 use crate::{ConfigurationProvider, OfflineMode, ServerClientImpl};
 
@@ -24,7 +24,7 @@ use super::ConfigurationId;
 
 /// AppConfiguration client implementation that connects to a server
 #[derive(Debug)]
-pub struct AppConfigurationClientHttp<T: LiveConfiguration> {
+pub(crate) struct AppConfigurationClientHttp<T: LiveConfiguration> {
     live_configuration: T,
 }
 
@@ -54,12 +54,6 @@ impl AppConfigurationClientHttp<LiveConfigurationImpl> {
     }
 }
 
-impl<T: LiveConfiguration> AppConfigurationClientHttp<T> {
-    pub fn is_online(&self) -> Result<bool> {
-        Ok(self.live_configuration.get_current_mode()? == CurrentMode::Online)
-    }
-}
-
 impl<T: LiveConfiguration> ConfigurationProvider for AppConfigurationClientHttp<T> {
     fn get_feature_ids(&self) -> Result<Vec<String>> {
         self.live_configuration.get_feature_ids()
@@ -76,6 +70,10 @@ impl<T: LiveConfiguration> ConfigurationProvider for AppConfigurationClientHttp<
     fn get_property(&self, property_id: &str) -> Result<PropertySnapshot> {
         self.live_configuration.get_property(property_id)
     }
+
+    fn is_online(&self) -> Result<bool> {
+        self.live_configuration.is_online()
+    }
 }
 
 #[cfg(test)]
@@ -86,6 +84,7 @@ mod tests {
         configuration_feature1_enabled, configuration_property1_enabled,
         example_configuration_enterprise,
     };
+    use crate::network::live_configuration::CurrentMode;
     use crate::utils::ThreadStatus;
     use crate::{models::ConfigurationJson, Feature, Property};
     use rstest::rstest;
@@ -108,6 +107,10 @@ mod tests {
 
         fn get_property(&self, property_id: &str) -> Result<PropertySnapshot> {
             self.configuration.get_property(property_id)
+        }
+
+        fn is_online(&self) -> Result<bool> {
+            todo!()
         }
     }
     impl LiveConfiguration for LiveConfigurationMock {

--- a/src/client/app_configuration_ibm_cloud.rs
+++ b/src/client/app_configuration_ibm_cloud.rs
@@ -19,8 +19,8 @@ use crate::network::live_configuration::LiveConfigurationImpl;
 use crate::network::ServiceAddress;
 use crate::{ConfigurationProvider, IBMCloudTokenProvider, OfflineMode};
 
-use super::AppConfigurationClientHttp;
 use super::ConfigurationId;
+use crate::client::app_configuration_http::AppConfigurationClientHttp;
 
 /// AppConfiguration client connection to IBM Cloud.
 #[derive(Debug)]
@@ -82,6 +82,10 @@ impl ConfigurationProvider for AppConfigurationClientIBMCloud {
 
     fn get_property(&self, property_id: &str) -> Result<PropertySnapshot> {
         self.client.get_property(property_id)
+    }
+
+    fn is_online(&self) -> Result<bool> {
+        self.client.is_online()
     }
 }
 

--- a/src/client/app_configuration_offline.rs
+++ b/src/client/app_configuration_offline.rs
@@ -56,4 +56,8 @@ impl ConfigurationProvider for AppConfigurationOffline {
     fn get_property(&self, property_id: &str) -> Result<PropertySnapshot> {
         self.config_snapshot.get_property(property_id)
     }
+
+    fn is_online(&self) -> Result<bool> {
+        Ok(false)
+    }
 }

--- a/src/client/configuration.rs
+++ b/src/client/configuration.rs
@@ -181,6 +181,10 @@ impl ConfigurationProvider for Configuration {
             &property.name,
         ))
     }
+
+    fn is_online(&self) -> Result<bool> {
+        Ok(false)
+    }
 }
 
 #[cfg(test)]

--- a/src/client/metering.rs
+++ b/src/client/metering.rs
@@ -109,7 +109,7 @@ mod tests {
     use crate::models::ConfigurationJson;
     use crate::models::MeteringDataJson;
     use crate::network::http_client::WebsocketReader;
-    use crate::NetworkResult;
+    use crate::network::NetworkResult;
 
     struct ServerClientMock {
         metering_data_sender: mpsc::Sender<()>,
@@ -147,7 +147,7 @@ mod tests {
             &self,
             _collection: &ConfigurationId,
         ) -> NetworkResult<impl WebsocketReader> {
-            unreachable!() as crate::NetworkResult<WebsocketMockReader>
+            unreachable!() as NetworkResult<WebsocketMockReader>
         }
 
         fn push_metering_data(&self, _data: &MeteringDataJson) -> NetworkResult<()> {

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -26,6 +26,7 @@ pub(crate) mod property_snapshot;
 pub use app_configuration_client::{
     AppConfigurationClient, ConfigurationId, ConfigurationProvider,
 };
-pub use app_configuration_http::AppConfigurationClientHttp;
+
+pub(crate) use app_configuration_http::AppConfigurationClientHttp;
 pub use app_configuration_ibm_cloud::AppConfigurationClientIBMCloud;
 pub use app_configuration_offline::AppConfigurationOffline;

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 mod app_configuration_client;
-mod app_configuration_http;
+pub(crate) mod app_configuration_http;
 mod app_configuration_ibm_cloud;
 mod app_configuration_offline;
 
@@ -28,6 +28,5 @@ pub use app_configuration_client::{
     AppConfigurationClient, ConfigurationId, ConfigurationProvider,
 };
 
-pub(crate) use app_configuration_http::AppConfigurationClientHttp;
 pub use app_configuration_ibm_cloud::AppConfigurationClientIBMCloud;
 pub use app_configuration_offline::AppConfigurationOffline;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,11 +104,9 @@ pub(crate) use network::{IBMCloudTokenProvider, ServerClientImpl};
 pub use property::Property;
 pub use value::Value;
 
-#[cfg(feature = "http_client")]
-pub use client::AppConfigurationClientHttp;
-#[cfg(feature = "http_client")]
-pub use network::live_configuration::LiveConfiguration;
-#[cfg(feature = "http_client")]
-pub use network::{NetworkError, NetworkResult, ServiceAddress, TokenProvider};
+pub use network::ServiceAddress;
 #[cfg(test)]
 mod tests;
+
+#[cfg(feature = "test_utils")]
+pub mod test_utils;

--- a/src/models.rs
+++ b/src/models.rs
@@ -24,7 +24,7 @@ use crate::{errors::DeserializationError, Error, Result, Value};
 /// - AppConfig database dumps (via Web GUI)
 /// - Offline configuration files used in offline-mode
 #[derive(Debug, Deserialize)]
-pub struct ConfigurationJson {
+pub(crate) struct ConfigurationJson {
     pub environments: Vec<Environment>,
     pub segments: Vec<Segment>,
 }
@@ -53,14 +53,14 @@ impl ConfigurationJson {
 }
 
 #[derive(Debug, Deserialize)]
-pub struct Environment {
+pub(crate) struct Environment {
     pub environment_id: String,
     pub features: Vec<Feature>,
     pub properties: Vec<Property>,
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
-pub struct Segment {
+pub(crate) struct Segment {
     pub name: String,
     pub segment_id: String,
     pub description: String,
@@ -69,7 +69,7 @@ pub struct Segment {
 }
 
 #[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
-pub struct Feature {
+pub(crate) struct Feature {
     pub name: String,
     pub feature_id: String,
     pub r#type: ValueType,
@@ -82,7 +82,7 @@ pub struct Feature {
 }
 
 #[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
-pub struct Property {
+pub(crate) struct Property {
     pub name: String,
     pub property_id: String,
     pub r#type: ValueType,
@@ -93,7 +93,7 @@ pub struct Property {
 }
 
 #[derive(Copy, Clone, Debug, Deserialize, PartialEq, Eq)]
-pub enum ValueType {
+pub(crate) enum ValueType {
     #[serde(rename(deserialize = "NUMERIC"))]
     Numeric,
     #[serde(rename(deserialize = "BOOLEAN"))]
@@ -114,7 +114,7 @@ impl Display for ValueType {
 }
 
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
-pub struct ConfigValue(pub(crate) serde_json::Value);
+pub(crate) struct ConfigValue(pub(crate) serde_json::Value);
 
 impl ConfigValue {
     pub fn as_i64(&self) -> Option<i64> {
@@ -186,7 +186,7 @@ impl TryFrom<(ValueType, ConfigValue)> for Value {
 /// Represents a Rule of a Segment.
 /// Those are the rules to check if an entity belongs to a segment.
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
-pub struct Rule {
+pub(crate) struct Rule {
     pub attribute_name: String,
     pub operator: String,
     pub values: Vec<String>,
@@ -194,7 +194,7 @@ pub struct Rule {
 
 /// Associates a Feature/Property to one or more Segments
 #[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
-pub struct SegmentRule {
+pub(crate) struct SegmentRule {
     /// The list of targeted segments
     /// NOTE: no rules by itself, but the rules are found in the segments
     /// NOTE: why list of lists?
@@ -206,7 +206,7 @@ pub struct SegmentRule {
 }
 
 #[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
-pub struct Segments {
+pub(crate) struct Segments {
     pub segments: Vec<String>,
 }
 

--- a/src/network/live_configuration/mod.rs
+++ b/src/network/live_configuration/mod.rs
@@ -20,5 +20,6 @@ mod update_thread_worker;
 
 pub(crate) use current_mode::CurrentMode;
 pub(crate) use errors::{Error, Result};
-pub use live_configuration::{LiveConfiguration, LiveConfigurationImpl};
+pub use live_configuration::LiveConfiguration;
+pub(crate) use live_configuration::LiveConfigurationImpl;
 pub use offline_mode::OfflineMode;

--- a/src/network/live_configuration/update_thread_worker.rs
+++ b/src/network/live_configuration/update_thread_worker.rs
@@ -188,6 +188,8 @@ impl<T: ServerClient> UpdateThreadWorker<T> {
 
 #[cfg(test)]
 mod tests {
+    use crate::network::NetworkResult;
+
     use super::*;
 
     struct WebsocketMockReader {
@@ -205,7 +207,7 @@ mod tests {
             fn get_configuration(
                 &self,
                 _configuration_id: &ConfigurationId,
-            ) -> crate::NetworkResult<crate::models::ConfigurationJson> {
+            ) -> NetworkResult<crate::models::ConfigurationJson> {
                 Ok(crate::models::tests::configuration_feature1_enabled())
             }
 
@@ -213,8 +215,8 @@ mod tests {
             fn get_configuration_monitoring_websocket(
                 &self,
                 _collection: &ConfigurationId,
-            ) -> crate::NetworkResult<impl WebsocketReader> {
-                unreachable!() as crate::NetworkResult<WebsocketMockReader>
+            ) -> NetworkResult<impl WebsocketReader> {
+                unreachable!() as NetworkResult<WebsocketMockReader>
             }
         }
         let configuration_id = ConfigurationId::new("".into(), "environment_id".into(), "".into());
@@ -244,7 +246,7 @@ mod tests {
             fn get_configuration(
                 &self,
                 _configuration_id: &ConfigurationId,
-            ) -> crate::NetworkResult<crate::models::ConfigurationJson> {
+            ) -> NetworkResult<crate::models::ConfigurationJson> {
                 Ok(crate::models::tests::configuration_feature1_enabled())
             }
 
@@ -252,8 +254,8 @@ mod tests {
             fn get_configuration_monitoring_websocket(
                 &self,
                 _collection: &ConfigurationId,
-            ) -> crate::NetworkResult<impl WebsocketReader> {
-                unreachable!() as crate::NetworkResult<WebsocketMockReader>
+            ) -> NetworkResult<impl WebsocketReader> {
+                unreachable!() as NetworkResult<WebsocketMockReader>
             }
         }
         let configuration_id =
@@ -287,16 +289,16 @@ mod tests {
             fn get_configuration(
                 &self,
                 _configuration_id: &ConfigurationId,
-            ) -> crate::NetworkResult<crate::models::ConfigurationJson> {
-                Err(crate::NetworkError::ProtocolError)
+            ) -> NetworkResult<crate::models::ConfigurationJson> {
+                Err(NetworkError::ProtocolError)
             }
 
             #[allow(unreachable_code)]
             fn get_configuration_monitoring_websocket(
                 &self,
                 _collection: &ConfigurationId,
-            ) -> crate::NetworkResult<impl WebsocketReader> {
-                unreachable!() as crate::NetworkResult<WebsocketMockReader>
+            ) -> NetworkResult<impl WebsocketReader> {
+                unreachable!() as NetworkResult<WebsocketMockReader>
             }
         }
         let configuration_id = ConfigurationId::new("".into(), "environment_id".into(), "".into());
@@ -339,16 +341,16 @@ mod tests {
             fn get_configuration(
                 &self,
                 _configuration_id: &ConfigurationId,
-            ) -> crate::NetworkResult<crate::models::ConfigurationJson> {
-                Err(crate::NetworkError::CannotAcquireLock)
+            ) -> NetworkResult<crate::models::ConfigurationJson> {
+                Err(NetworkError::CannotAcquireLock)
             }
 
             #[allow(unreachable_code)]
             fn get_configuration_monitoring_websocket(
                 &self,
                 _collection: &ConfigurationId,
-            ) -> crate::NetworkResult<impl WebsocketReader> {
-                unreachable!() as crate::NetworkResult<WebsocketMockReader>
+            ) -> NetworkResult<impl WebsocketReader> {
+                unreachable!() as NetworkResult<WebsocketMockReader>
             }
         }
         let configuration_id = ConfigurationId::new("".into(), "environment_id".into(), "".into());
@@ -376,7 +378,7 @@ mod tests {
             fn get_configuration(
                 &self,
                 _configuration_id: &ConfigurationId,
-            ) -> crate::NetworkResult<crate::models::ConfigurationJson> {
+            ) -> NetworkResult<crate::models::ConfigurationJson> {
                 Ok(crate::models::tests::configuration_feature1_enabled())
             }
 
@@ -384,8 +386,8 @@ mod tests {
             fn get_configuration_monitoring_websocket(
                 &self,
                 _collection: &ConfigurationId,
-            ) -> crate::NetworkResult<impl WebsocketReader> {
-                unreachable!() as crate::NetworkResult<WebsocketMockReader>
+            ) -> NetworkResult<impl WebsocketReader> {
+                unreachable!() as NetworkResult<WebsocketMockReader>
             }
         }
         let configuration_id = ConfigurationId::new("".into(), "environment_id".into(), "".into());
@@ -453,16 +455,16 @@ mod tests {
             fn get_configuration(
                 &self,
                 _configuration_id: &ConfigurationId,
-            ) -> crate::NetworkResult<crate::models::ConfigurationJson> {
-                Err(crate::NetworkError::UrlParseError("".to_string()))
+            ) -> NetworkResult<crate::models::ConfigurationJson> {
+                Err(NetworkError::UrlParseError("".to_string()))
             }
 
             #[allow(unreachable_code)]
             fn get_configuration_monitoring_websocket(
                 &self,
                 _collection: &ConfigurationId,
-            ) -> crate::NetworkResult<impl WebsocketReader> {
-                unreachable!() as crate::NetworkResult<WebsocketMockReader>
+            ) -> NetworkResult<impl WebsocketReader> {
+                unreachable!() as NetworkResult<WebsocketMockReader>
             }
         }
         let configuration_id = ConfigurationId::new("".into(), "environment_id".into(), "".into());
@@ -507,7 +509,7 @@ mod tests {
             fn get_configuration(
                 &self,
                 _configuration_id: &ConfigurationId,
-            ) -> crate::NetworkResult<crate::models::ConfigurationJson> {
+            ) -> NetworkResult<crate::models::ConfigurationJson> {
                 unreachable!()
             }
 
@@ -515,8 +517,8 @@ mod tests {
             fn get_configuration_monitoring_websocket(
                 &self,
                 _collection: &ConfigurationId,
-            ) -> crate::NetworkResult<impl WebsocketReader> {
-                unreachable!() as crate::NetworkResult<WebsocketMockReader>
+            ) -> NetworkResult<impl WebsocketReader> {
+                unreachable!() as NetworkResult<WebsocketMockReader>
             }
         }
         let configuration_id = ConfigurationId::new("".into(), "environment_id".into(), "".into());
@@ -556,16 +558,16 @@ mod tests {
             fn get_configuration(
                 &self,
                 _configuration_id: &ConfigurationId,
-            ) -> crate::NetworkResult<crate::models::ConfigurationJson> {
+            ) -> NetworkResult<crate::models::ConfigurationJson> {
                 self.tx.send("get_configuration".to_string()).unwrap();
-                Err(crate::NetworkError::UrlParseError("".to_string()))
+                Err(NetworkError::UrlParseError("".to_string()))
             }
 
             #[allow(unreachable_code)]
             fn get_configuration_monitoring_websocket(
                 &self,
                 _collection: &ConfigurationId,
-            ) -> crate::NetworkResult<impl WebsocketReader> {
+            ) -> NetworkResult<impl WebsocketReader> {
                 self.tx
                     .send("get_configuration_monitoring_websocket".to_string())
                     .unwrap();
@@ -618,15 +620,15 @@ mod tests {
             fn get_configuration(
                 &self,
                 _configuration_id: &ConfigurationId,
-            ) -> crate::NetworkResult<crate::models::ConfigurationJson> {
+            ) -> NetworkResult<crate::models::ConfigurationJson> {
                 Ok(crate::models::tests::configuration_feature1_enabled())
             }
 
             fn get_configuration_monitoring_websocket(
                 &self,
                 _collection: &ConfigurationId,
-            ) -> crate::NetworkResult<impl WebsocketReader> {
-                Err::<WebsocketMockReader, _>(crate::NetworkError::InvalidHeaderValue("".into()))
+            ) -> NetworkResult<impl WebsocketReader> {
+                Err::<WebsocketMockReader, _>(NetworkError::InvalidHeaderValue("".into()))
             }
         }
         let configuration_id = ConfigurationId::new("".into(), "environment_id".into(), "".into());
@@ -656,14 +658,14 @@ mod tests {
             fn get_configuration(
                 &self,
                 _configuration_id: &ConfigurationId,
-            ) -> crate::NetworkResult<crate::models::ConfigurationJson> {
+            ) -> NetworkResult<crate::models::ConfigurationJson> {
                 Ok(crate::models::tests::configuration_feature1_enabled())
             }
 
             fn get_configuration_monitoring_websocket(
                 &self,
                 _collection: &ConfigurationId,
-            ) -> crate::NetworkResult<impl WebsocketReader> {
+            ) -> NetworkResult<impl WebsocketReader> {
                 Ok(WebsocketMockReader {
                     message: Some(Err(tungstenite::Error::AttackAttempt)),
                 })
@@ -689,20 +691,20 @@ mod tests {
     #[test]
     fn test_run_websocket_reconnect() {
         struct ServerClientMock {
-            rx: std::sync::mpsc::Receiver<crate::NetworkResult<WebsocketMockReader>>,
+            rx: std::sync::mpsc::Receiver<NetworkResult<WebsocketMockReader>>,
         }
         impl ServerClient for ServerClientMock {
             fn get_configuration(
                 &self,
                 _configuration_id: &ConfigurationId,
-            ) -> crate::NetworkResult<crate::models::ConfigurationJson> {
+            ) -> NetworkResult<crate::models::ConfigurationJson> {
                 Ok(crate::models::tests::configuration_feature1_enabled())
             }
 
             fn get_configuration_monitoring_websocket(
                 &self,
                 _collection: &ConfigurationId,
-            ) -> crate::NetworkResult<impl WebsocketReader> {
+            ) -> NetworkResult<impl WebsocketReader> {
                 self.rx.recv().unwrap()
             }
         }

--- a/src/test_utils/mod.rs
+++ b/src/test_utils/mod.rs
@@ -1,8 +1,7 @@
-use crate::client::AppConfigurationClientHttp;
+use crate::client::app_configuration_http::AppConfigurationClientHttp;
 use crate::network::{NetworkResult, ServiceAddress, TokenProvider};
 use crate::{AppConfigurationClient, Result};
 use crate::{ConfigurationId, OfflineMode};
-
 #[derive(Debug)]
 struct MockTokenProvider {}
 

--- a/src/test_utils/mod.rs
+++ b/src/test_utils/mod.rs
@@ -1,0 +1,31 @@
+use crate::client::AppConfigurationClientHttp;
+use crate::network::{NetworkResult, ServiceAddress, TokenProvider};
+use crate::{AppConfigurationClient, Result};
+use crate::{ConfigurationId, OfflineMode};
+
+#[derive(Debug)]
+struct MockTokenProvider {}
+
+impl TokenProvider for MockTokenProvider {
+    fn get_access_token(&self) -> NetworkResult<String> {
+        Ok("mock_token".into())
+    }
+}
+
+/// Creates and returns an [`AppConfigurationClient`]-like object that connects to
+/// the given server.
+pub fn create_app_configuration_client_live(
+    service_address: ServiceAddress,
+    configuration_id: ConfigurationId,
+    offline_mode: OfflineMode,
+) -> Result<Box<dyn AppConfigurationClient>> {
+    let token_provider = Box::new(MockTokenProvider {});
+    let client = AppConfigurationClientHttp::new(
+        service_address,
+        token_provider,
+        configuration_id,
+        offline_mode,
+    )?;
+
+    Ok(Box::new(client))
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -8,15 +8,6 @@ use std::thread::sleep;
 use std::time::Duration;
 use tungstenite::WebSocket;
 
-// #[derive(Debug)]
-// pub struct MockTokenProvider {}
-
-// impl TokenProvider for MockTokenProvider {
-//     fn get_access_token(&self) -> appconfiguration::NetworkResult<String> {
-//         Ok("mock_token".into())
-//     }
-// }
-
 pub fn handle_config_request_trivial_config(server: &TcpListener) {
     let json_payload = serde_json::json!({
         "environments": [

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,4 +1,4 @@
-use appconfiguration::{AppConfigurationClientHttp, LiveConfiguration, TokenProvider};
+use appconfiguration::AppConfigurationClient;
 
 use std::io::{BufRead, BufReader, Write};
 use std::net::{TcpListener, TcpStream};
@@ -8,14 +8,14 @@ use std::thread::sleep;
 use std::time::Duration;
 use tungstenite::WebSocket;
 
-#[derive(Debug)]
-pub struct MockTokenProvider {}
+// #[derive(Debug)]
+// pub struct MockTokenProvider {}
 
-impl TokenProvider for MockTokenProvider {
-    fn get_access_token(&self) -> appconfiguration::NetworkResult<String> {
-        Ok("mock_token".into())
-    }
-}
+// impl TokenProvider for MockTokenProvider {
+//     fn get_access_token(&self) -> appconfiguration::NetworkResult<String> {
+//         Ok("mock_token".into())
+//     }
+// }
 
 pub fn handle_config_request_trivial_config(server: &TcpListener) {
     let json_payload = serde_json::json!({
@@ -68,7 +68,7 @@ pub fn handle_websocket(server: &TcpListener) -> WebSocket<TcpStream> {
     websocket
 }
 
-pub fn wait_until_online<T: LiveConfiguration>(client: &AppConfigurationClientHttp<T>) {
+pub fn wait_until_online(client: &Box<dyn AppConfigurationClient>) {
     loop {
         if client.is_online().unwrap() {
             break;

--- a/tests/test_initial_configuration_from_server.rs
+++ b/tests/test_initial_configuration_from_server.rs
@@ -1,6 +1,4 @@
-use appconfiguration::{
-    AppConfigurationClientHttp, ConfigurationId, ConfigurationProvider, OfflineMode, ServiceAddress,
-};
+use appconfiguration::{ConfigurationId, OfflineMode, ServiceAddress};
 
 use std::net::TcpListener;
 use std::sync::mpsc::channel;
@@ -62,9 +60,8 @@ fn main() {
         "dev".to_string(),
         "collection_id".to_string(),
     );
-    let client = AppConfigurationClientHttp::new(
+    let client = appconfiguration::test_utils::create_app_configuration_client_live(
         address,
-        Box::new(common::MockTokenProvider {}),
         config_id,
         OfflineMode::Fail,
     )

--- a/tests/test_offline_mode.rs
+++ b/tests/test_offline_mode.rs
@@ -1,7 +1,4 @@
-use appconfiguration::{
-    AppConfigurationClientHttp, AppConfigurationOffline, ConfigurationId, ConfigurationProvider,
-    OfflineMode, ServiceAddress,
-};
+use appconfiguration::{AppConfigurationOffline, ConfigurationId, OfflineMode, ServiceAddress};
 
 use std::net::TcpListener;
 
@@ -33,9 +30,8 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
             "collection_id".to_string(),
         );
 
-        AppConfigurationClientHttp::new(
+        appconfiguration::test_utils::create_app_configuration_client_live(
             address,
-            Box::new(common::MockTokenProvider {}),
             config_id,
             OfflineMode::FallbackData(offline_data),
         )

--- a/tests/test_ws_connection_close.rs
+++ b/tests/test_ws_connection_close.rs
@@ -1,6 +1,4 @@
-use appconfiguration::{
-    AppConfigurationClientHttp, ConfigurationId, ConfigurationProvider, OfflineMode, ServiceAddress,
-};
+use appconfiguration::{ConfigurationId, OfflineMode, ServiceAddress};
 
 use std::net::TcpListener;
 
@@ -56,9 +54,8 @@ fn main() {
         "dev".to_string(),
         "collection_id".to_string(),
     );
-    let client = AppConfigurationClientHttp::new(
+    let client = appconfiguration::test_utils::create_app_configuration_client_live(
         address,
-        Box::new(common::MockTokenProvider {}),
         config_id,
         OfflineMode::Fail,
     )


### PR DESCRIPTION
I realized that the main blocker we had to hide most of our API was the `AppConfigurationClientHttp`. This API of this object was allowing the user to provide something that exposed the `Configuration` type. That's all. With this in mind, there is no way we can hide the `Configuration`.

However, if we have a look, the only purpose of `AppConfigurationClietHttp` is to provide a way to inject behaviour, and right now we are only using it to write our integration tests. **We cannot make something public just because we need it to write tests**.

So, here are the main changes:
 * Hide `AppConfigurationClientHttp`
 * Provide a new `test_utils` module that basically calls the `AppConfigurationClientHttp` ctor and returns the interface.
 * Now we can make `Configuration` private 😃 