### PR TITLE
refact: `network` module returns `Configuration` object

### DIFF
--- a/src/client/app_configuration_http.rs
+++ b/src/client/app_configuration_http.rs
@@ -87,7 +87,7 @@ mod tests {
     };
     use crate::network::live_configuration::CurrentMode;
     use crate::utils::ThreadStatus;
-    use crate::{models::ConfigurationJson, Feature, Property};
+    use crate::{Feature, Property};
     use rstest::rstest;
 
     struct LiveConfigurationMock {
@@ -128,15 +128,12 @@ mod tests {
 
     #[rstest]
     fn test_get_feature_persistence(
-        example_configuration_enterprise: ConfigurationJson,
-        configuration_feature1_enabled: ConfigurationJson,
+        example_configuration_enterprise: Configuration,
+        configuration_feature1_enabled: Configuration,
     ) {
         let mut client = {
-            let configuration_snapshot =
-                Configuration::new("dev", example_configuration_enterprise).unwrap();
-
             let live_cfg_mock = LiveConfigurationMock {
-                configuration: configuration_snapshot,
+                configuration: example_configuration_enterprise,
             };
 
             AppConfigurationClientHttp {
@@ -150,10 +147,8 @@ mod tests {
         let feature_value1 = feature.get_value(&entity).unwrap();
 
         // We simulate an update of the configuration:
-        let configuration_snapshot =
-            Configuration::new("environment_id", configuration_feature1_enabled).unwrap();
         client.live_configuration = LiveConfigurationMock {
-            configuration: configuration_snapshot,
+            configuration: configuration_feature1_enabled,
         };
         // The feature value should not have changed (as we did not retrieve it again)
         let feature_value2 = feature.get_value(&entity).unwrap();
@@ -168,15 +163,12 @@ mod tests {
 
     #[rstest]
     fn test_get_property_persistence(
-        example_configuration_enterprise: ConfigurationJson,
-        configuration_property1_enabled: ConfigurationJson,
+        example_configuration_enterprise: Configuration,
+        configuration_property1_enabled: Configuration,
     ) {
         let mut client = {
-            let configuration_snapshot =
-                Configuration::new("dev", example_configuration_enterprise).unwrap();
-
             let live_cfg_mock = LiveConfigurationMock {
-                configuration: configuration_snapshot,
+                configuration: example_configuration_enterprise,
             };
 
             AppConfigurationClientHttp {
@@ -190,10 +182,8 @@ mod tests {
         let property_value1 = property.get_value(&entity).unwrap();
 
         // We simulate an update of the configuration:
-        let configuration_snapshot =
-            Configuration::new("environment_id", configuration_property1_enabled).unwrap();
         client.live_configuration = LiveConfigurationMock {
-            configuration: configuration_snapshot,
+            configuration: configuration_property1_enabled,
         };
         // The property value should not have changed (as we did not retrieve it again)
         let property_value2 = property.get_value(&entity).unwrap();

--- a/src/client/app_configuration_offline.rs
+++ b/src/client/app_configuration_offline.rs
@@ -17,7 +17,6 @@ use crate::client::configuration::Configuration;
 use crate::client::feature_snapshot::FeatureSnapshot;
 use crate::client::property_snapshot::PropertySnapshot;
 use crate::errors::Result;
-use crate::models::ConfigurationJson;
 use crate::ConfigurationProvider;
 
 /// AppConfiguration client using a local file with a configuration snapshot
@@ -34,8 +33,7 @@ impl AppConfigurationOffline {
     /// * `filepath` - The file with the configuration.
     /// * `environment_id` - ID of the environment to use from the configuration file.
     pub fn new(filepath: &std::path::Path, environment_id: &str) -> Result<Self> {
-        let configuration = ConfigurationJson::new(filepath)?;
-        let config_snapshot = Configuration::new(environment_id, configuration)?;
+        let config_snapshot = Configuration::from_file(filepath, environment_id)?;
         Ok(Self { config_snapshot })
     }
 }

--- a/src/client/metering.rs
+++ b/src/client/metering.rs
@@ -211,7 +211,8 @@ impl<T: ServerClient> MeteringBatcher<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::models::ConfigurationJson;
+    use crate::client::configuration::Configuration;
+
     use crate::models::MeteringDataJson;
     use crate::network::http_client::WebsocketReader;
     use crate::network::NetworkResult;
@@ -244,7 +245,7 @@ mod tests {
         fn get_configuration(
             &self,
             _configuration_id: &ConfigurationId,
-        ) -> NetworkResult<ConfigurationJson> {
+        ) -> NetworkResult<Configuration> {
             unreachable!()
         }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -44,6 +44,9 @@ pub enum Error {
     #[error(transparent)]
     ConfigurationAccessError(#[from] ConfigurationAccessError),
 
+    #[error(transparent)]
+    ConfigurationDataError(#[from] ConfigurationDataError),
+
     #[error("Failed to evaluate entity: {0}")]
     EntityEvaluationError(EntityEvaluationError),
 
@@ -92,23 +95,24 @@ pub enum DeserializationErrorKind {
 }
 
 #[derive(Debug, Error)]
+pub enum ConfigurationDataError {
+    #[error("Environment '{0}' not found")]
+    EnvironmentNotFound(String),
+
+    #[error("Feature `{0}` not found.")]
+    FeatureNotFound(String),
+
+    #[error("Property `{0}` not found.")]
+    PropertyNotFound(String),
+
+    #[error("Missing segments for resource '{0}'")]
+    MissingSegments(String),
+}
+
+#[derive(Debug, Error)]
 pub enum ConfigurationAccessError {
     #[error("Error acquiring index cache lock")]
     LockAcquisitionError,
-
-    #[error(
-        "Environment '{environment_id}' indicated as key not found in the configuration instance"
-    )]
-    EnvironmentNotFound { environment_id: String },
-
-    #[error("Feature `{feature_id}` not found.")]
-    FeatureNotFound { feature_id: String },
-
-    #[error("Property `{property_id}` not found.")]
-    PropertyNotFound { property_id: String },
-
-    #[error("Missing segments for resource '{resource_id}'")]
-    MissingSegments { resource_id: String },
 }
 
 impl<T> From<PoisonError<T>> for ConfigurationAccessError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,7 +97,7 @@ pub use client::{
     ConfigurationId, ConfigurationProvider,
 };
 pub use entity::Entity;
-pub use errors::{Error, Result};
+pub use errors::{ConfigurationDataError, Error, Result};
 pub use feature::Feature;
 pub use network::live_configuration::OfflineMode;
 pub(crate) use network::{IBMCloudTokenProvider, ServerClientImpl};

--- a/src/models.rs
+++ b/src/models.rs
@@ -237,6 +237,8 @@ pub(crate) struct Segments {
 #[cfg(test)]
 pub(crate) mod tests {
 
+    use crate::client::configuration::Configuration;
+
     use super::*;
     use rstest::*;
     use std::{fs, path::PathBuf};
@@ -254,19 +256,20 @@ pub(crate) mod tests {
     // Creates a [`ConfigurationJson`] object from the data files
     pub(crate) fn example_configuration_enterprise(
         example_configuration_enterprise_path: PathBuf,
-    ) -> ConfigurationJson {
+    ) -> Configuration {
         let content = fs::File::open(example_configuration_enterprise_path)
             .expect("file should open read only");
-        let configuration: ConfigurationJson =
+        let config_json: ConfigurationJson =
             serde_json::from_reader(content).expect("Error parsing JSON into Configuration");
-        configuration
+        Configuration::new("dev", config_json).unwrap()
     }
 
     #[fixture]
-    pub(crate) fn configuration_feature1_enabled() -> ConfigurationJson {
-        ConfigurationJson {
+    pub(crate) fn configuration_feature1_enabled() -> Configuration {
+        let environment_id = "environment_id".to_string();
+        let config_json = ConfigurationJson {
             environments: vec![Environment {
-                environment_id: "environment_id".to_string(),
+                environment_id: environment_id.clone(),
                 features: vec![Feature {
                     name: "F1".to_string(),
                     feature_id: "f1".to_string(),
@@ -281,14 +284,16 @@ pub(crate) mod tests {
                 properties: Vec::new(),
             }],
             segments: Vec::new(),
-        }
+        };
+        Configuration::new(&environment_id, config_json).unwrap()
     }
 
     #[fixture]
-    pub(crate) fn configuration_property1_enabled() -> ConfigurationJson {
-        ConfigurationJson {
+    pub(crate) fn configuration_property1_enabled() -> Configuration {
+        let environment_id = "environment_id".to_string();
+        let config_json = ConfigurationJson {
             environments: vec![Environment {
-                environment_id: "environment_id".to_string(),
+                environment_id: environment_id.clone(),
                 properties: vec![Property {
                     name: "P1".to_string(),
                     property_id: "p1".to_string(),
@@ -301,11 +306,12 @@ pub(crate) mod tests {
                 features: Vec::new(),
             }],
             segments: Vec::new(),
-        }
+        };
+        Configuration::new(&environment_id, config_json).unwrap()
     }
 
     #[fixture]
-    pub(crate) fn configuration_unordered_segment_rules() -> ConfigurationJson {
+    pub(crate) fn configuration_unordered_segment_rules() -> Configuration {
         let segment_rules = vec![
             SegmentRule {
                 rules: vec![Segments {
@@ -326,9 +332,10 @@ pub(crate) mod tests {
         ];
         assert!(segment_rules[0].order > segment_rules[1].order);
 
-        ConfigurationJson {
+        let environment_id = "environment_id".to_string();
+        let config_json = ConfigurationJson {
             environments: vec![Environment {
-                environment_id: "environment_id".to_string(),
+                environment_id: environment_id.clone(),
                 features: vec![Feature {
                     name: "F1".to_string(),
                     feature_id: "f1".to_string(),
@@ -374,6 +381,7 @@ pub(crate) mod tests {
                     }],
                 },
             ],
-        }
+        };
+        Configuration::new(&environment_id, config_json).unwrap()
     }
 }

--- a/src/network/errors.rs
+++ b/src/network/errors.rs
@@ -16,6 +16,8 @@ use std::sync::PoisonError;
 
 use thiserror::Error;
 
+use crate::ConfigurationDataError;
+
 #[derive(Debug, Error)]
 pub enum NetworkError {
     #[error(transparent)]
@@ -38,6 +40,9 @@ pub enum NetworkError {
 
     #[error("Contact to server lost")]
     ContactToServerLost,
+
+    #[error(transparent)]
+    ConfigurationDataError(#[from] ConfigurationDataError),
 }
 
 impl<T> From<PoisonError<T>> for NetworkError {

--- a/src/network/live_configuration/current_mode.rs
+++ b/src/network/live_configuration/current_mode.rs
@@ -23,11 +23,11 @@ pub enum CurrentMode {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum CurrentModeOfflineReason {
+    // Request error, or configuration data was invalid
     FailedToGetNewConfiguration,
     Initializing,
     WebsocketClosed,
     WebsocketError,
-    ConfigurationDataInvalid,
 }
 
 impl std::fmt::Display for CurrentModeOfflineReason {
@@ -39,9 +39,6 @@ impl std::fmt::Display for CurrentModeOfflineReason {
             CurrentModeOfflineReason::Initializing => write!(f, "Initializing"),
             CurrentModeOfflineReason::WebsocketClosed => write!(f, "WebsocketClosed"),
             CurrentModeOfflineReason::WebsocketError => write!(f, "WebsocketError"),
-            CurrentModeOfflineReason::ConfigurationDataInvalid => {
-                write!(f, "ConfigurationDataInvalid")
-            }
         }
     }
 }

--- a/src/network/live_configuration/live_configuration.rs
+++ b/src/network/live_configuration/live_configuration.rs
@@ -191,14 +191,14 @@ mod tests {
             }
         }
         struct ServerClientMock {
-            rx: mpsc::Receiver<crate::models::ConfigurationJson>,
+            rx: mpsc::Receiver<Configuration>,
             websocket_rx: mpsc::Receiver<WebsocketReaderMock>,
         }
         impl ServerClient for ServerClientMock {
             fn get_configuration(
                 &self,
                 _configuration_id: &ConfigurationId,
-            ) -> NetworkResult<crate::models::ConfigurationJson> {
+            ) -> NetworkResult<Configuration> {
                 Ok(self.rx.recv().unwrap())
             }
 
@@ -370,7 +370,7 @@ mod tests {
             offline_mode: OfflineMode::Fail,
             configuration: Arc::new(Mutex::new(Some(Configuration::default()))),
             current_mode: Arc::new(Mutex::new(CurrentMode::Offline(
-                CurrentModeOfflineReason::ConfigurationDataInvalid,
+                CurrentModeOfflineReason::WebsocketClosed,
             ))),
             update_thread: ThreadHandle {
                 _thread_termination_sender: tx,
@@ -385,7 +385,7 @@ mod tests {
             assert!(r.is_err(), "Error: {}", r.unwrap_err());
             assert_eq!(
                 r.unwrap_err(),
-                Error::Offline(CurrentModeOfflineReason::ConfigurationDataInvalid)
+                Error::Offline(CurrentModeOfflineReason::WebsocketClosed)
             );
         }
 

--- a/src/network/live_configuration/update_thread_worker.rs
+++ b/src/network/live_configuration/update_thread_worker.rs
@@ -102,28 +102,15 @@ impl<T: ServerClient> UpdateThreadWorker<T> {
     /// accordingly.
     fn update_configuration_from_server_and_current_mode(&self) -> Result<()> {
         match self.server_client.get_configuration(&self.configuration_id) {
-            Ok(config_json) => {
-                match Configuration::new(&self.configuration_id.environment_id, config_json) {
-                    Ok(config) => {
-                        *self.configuration.lock()? = Some(config);
-                        *self.current_mode.lock()? = CurrentMode::Online;
-                    }
-                    Err(_) => {
-                        *self.current_mode.lock()? = CurrentMode::Offline(
-                            CurrentModeOfflineReason::ConfigurationDataInvalid,
-                        );
-                    }
-                };
+            Ok(config) => {
+                *self.configuration.lock()? = Some(config);
+                *self.current_mode.lock()? = CurrentMode::Online;
                 Ok(())
             }
             Err(e) => {
                 Self::recoverable_error(e)?;
-                let current_mode = self.current_mode.lock()?.clone();
-                if let CurrentMode::Offline(_) = current_mode {
-                } else {
-                    *self.current_mode.lock()? =
-                        CurrentMode::Offline(CurrentModeOfflineReason::FailedToGetNewConfiguration);
-                }
+                *self.current_mode.lock()? =
+                    CurrentMode::Offline(CurrentModeOfflineReason::FailedToGetNewConfiguration);
                 Ok(())
             }
         }
@@ -182,13 +169,14 @@ impl<T: ServerClient> UpdateThreadWorker<T> {
             NetworkError::UrlParseError(e) => Err(Error::UnrecoverableError(e)),
             NetworkError::InvalidHeaderValue(e) => Err(Error::UnrecoverableError(e)),
             NetworkError::CannotAcquireLock => Err(Error::CannotAcquireLock),
+            NetworkError::ConfigurationDataError(_) => Ok(()),
         }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::network::NetworkResult;
+    use crate::{network::NetworkResult, ConfigurationDataError};
 
     use super::*;
 
@@ -207,7 +195,7 @@ mod tests {
             fn get_configuration(
                 &self,
                 _configuration_id: &ConfigurationId,
-            ) -> NetworkResult<crate::models::ConfigurationJson> {
+            ) -> NetworkResult<Configuration> {
                 Ok(crate::models::tests::configuration_feature1_enabled())
             }
 
@@ -246,8 +234,12 @@ mod tests {
             fn get_configuration(
                 &self,
                 _configuration_id: &ConfigurationId,
-            ) -> NetworkResult<crate::models::ConfigurationJson> {
-                Ok(crate::models::tests::configuration_feature1_enabled())
+            ) -> NetworkResult<Configuration> {
+                Err(ConfigurationDataError::EnvironmentNotFound(
+                    "environment not in response".to_string(),
+                )
+                .into())
+                // Err(network::errors::NetworkError::ConfigurationDataError(ConfigurationDataError::EnvironmentNotFound("environment not in response")))
             }
 
             #[allow(unreachable_code)]
@@ -258,8 +250,7 @@ mod tests {
                 unreachable!() as NetworkResult<WebsocketMockReader>
             }
         }
-        let configuration_id =
-            ConfigurationId::new("".into(), "non_existing_environment_id".into(), "".into());
+        let configuration_id = ConfigurationId::new("".into(), "not used".into(), "".into());
         let configuration = Arc::new(Mutex::new(None));
         let current_mode = Arc::new(Mutex::new(CurrentMode::Offline(
             CurrentModeOfflineReason::Initializing,
@@ -278,7 +269,7 @@ mod tests {
         assert!(configuration.lock().unwrap().is_none());
         assert_eq!(
             *current_mode.lock().unwrap(),
-            CurrentMode::Offline(CurrentModeOfflineReason::ConfigurationDataInvalid)
+            CurrentMode::Offline(CurrentModeOfflineReason::FailedToGetNewConfiguration)
         );
     }
 
@@ -289,7 +280,7 @@ mod tests {
             fn get_configuration(
                 &self,
                 _configuration_id: &ConfigurationId,
-            ) -> NetworkResult<crate::models::ConfigurationJson> {
+            ) -> NetworkResult<Configuration> {
                 Err(NetworkError::ProtocolError)
             }
 
@@ -321,17 +312,6 @@ mod tests {
             *current_mode.lock().unwrap(),
             CurrentMode::Offline(CurrentModeOfflineReason::FailedToGetNewConfiguration)
         );
-
-        // Test if offline mode is preserved:
-        *current_mode.lock().unwrap() =
-            CurrentMode::Offline(CurrentModeOfflineReason::Initializing);
-        let r = worker.update_configuration_from_server_and_current_mode();
-        assert!(r.is_ok());
-        assert!(configuration.lock().unwrap().is_none());
-        assert_eq!(
-            *current_mode.lock().unwrap(),
-            CurrentMode::Offline(CurrentModeOfflineReason::Initializing)
-        );
     }
 
     #[test]
@@ -341,7 +321,7 @@ mod tests {
             fn get_configuration(
                 &self,
                 _configuration_id: &ConfigurationId,
-            ) -> NetworkResult<crate::models::ConfigurationJson> {
+            ) -> NetworkResult<Configuration> {
                 Err(NetworkError::CannotAcquireLock)
             }
 
@@ -378,7 +358,7 @@ mod tests {
             fn get_configuration(
                 &self,
                 _configuration_id: &ConfigurationId,
-            ) -> NetworkResult<crate::models::ConfigurationJson> {
+            ) -> NetworkResult<Configuration> {
                 Ok(crate::models::tests::configuration_feature1_enabled())
             }
 
@@ -455,7 +435,7 @@ mod tests {
             fn get_configuration(
                 &self,
                 _configuration_id: &ConfigurationId,
-            ) -> NetworkResult<crate::models::ConfigurationJson> {
+            ) -> NetworkResult<Configuration> {
                 Err(NetworkError::UrlParseError("".to_string()))
             }
 
@@ -509,7 +489,7 @@ mod tests {
             fn get_configuration(
                 &self,
                 _configuration_id: &ConfigurationId,
-            ) -> NetworkResult<crate::models::ConfigurationJson> {
+            ) -> NetworkResult<Configuration> {
                 unreachable!()
             }
 
@@ -558,7 +538,7 @@ mod tests {
             fn get_configuration(
                 &self,
                 _configuration_id: &ConfigurationId,
-            ) -> NetworkResult<crate::models::ConfigurationJson> {
+            ) -> NetworkResult<Configuration> {
                 self.tx.send("get_configuration".to_string()).unwrap();
                 Err(NetworkError::UrlParseError("".to_string()))
             }
@@ -620,7 +600,7 @@ mod tests {
             fn get_configuration(
                 &self,
                 _configuration_id: &ConfigurationId,
-            ) -> NetworkResult<crate::models::ConfigurationJson> {
+            ) -> NetworkResult<Configuration> {
                 Ok(crate::models::tests::configuration_feature1_enabled())
             }
 
@@ -658,7 +638,7 @@ mod tests {
             fn get_configuration(
                 &self,
                 _configuration_id: &ConfigurationId,
-            ) -> NetworkResult<crate::models::ConfigurationJson> {
+            ) -> NetworkResult<Configuration> {
                 Ok(crate::models::tests::configuration_feature1_enabled())
             }
 
@@ -697,7 +677,7 @@ mod tests {
             fn get_configuration(
                 &self,
                 _configuration_id: &ConfigurationId,
-            ) -> NetworkResult<crate::models::ConfigurationJson> {
+            ) -> NetworkResult<Configuration> {
                 Ok(crate::models::tests::configuration_feature1_enabled())
             }
 

--- a/src/network/live_configuration/update_thread_worker.rs
+++ b/src/network/live_configuration/update_thread_worker.rs
@@ -239,7 +239,6 @@ mod tests {
                     "environment not in response".to_string(),
                 )
                 .into())
-                // Err(network::errors::NetworkError::ConfigurationDataError(ConfigurationDataError::EnvironmentNotFound("environment not in response")))
             }
 
             #[allow(unreachable_code)]

--- a/src/tests/test_get_feature.rs
+++ b/src/tests/test_get_feature.rs
@@ -14,8 +14,6 @@
 
 use std::collections::HashMap;
 
-use crate::models::ConfigurationJson;
-
 use crate::client::configuration::Configuration;
 use crate::{AppConfigurationClient, ConfigurationProvider};
 use crate::{AppConfigurationOffline, Value};
@@ -36,11 +34,10 @@ fn test_get_feature_doesnt_exist(client_enterprise: Box<dyn AppConfigurationClie
 }
 
 #[rstest]
-fn test_get_feature_ordered(configuration_unordered_segment_rules: ConfigurationJson) {
-    let config_snapshot =
-        Configuration::new("environment_id", configuration_unordered_segment_rules).unwrap();
-
-    let client = AppConfigurationOffline { config_snapshot };
+fn test_get_feature_ordered(configuration_unordered_segment_rules: Configuration) {
+    let client = AppConfigurationOffline {
+        config_snapshot: configuration_unordered_segment_rules,
+    };
 
     let entity = crate::tests::GenericEntity {
         id: "a2".into(),

--- a/src/tests/test_get_property.rs
+++ b/src/tests/test_get_property.rs
@@ -14,8 +14,6 @@
 
 use std::collections::HashMap;
 
-use crate::models::ConfigurationJson;
-
 use crate::client::configuration::Configuration;
 use crate::client::{AppConfigurationClient, AppConfigurationOffline};
 use crate::{ConfigurationProvider, Value};
@@ -36,11 +34,10 @@ fn test_get_property_doesnt_exist(client_enterprise: Box<dyn AppConfigurationCli
 }
 
 #[rstest]
-fn test_get_property_ordered(configuration_unordered_segment_rules: ConfigurationJson) {
-    let config_snapshot =
-        Configuration::new("environment_id", configuration_unordered_segment_rules).unwrap();
-
-    let client = AppConfigurationOffline { config_snapshot };
+fn test_get_property_ordered(configuration_unordered_segment_rules: Configuration) {
+    let client = AppConfigurationOffline {
+        config_snapshot: configuration_unordered_segment_rules,
+    };
 
     let entity = crate::tests::GenericEntity {
         id: "a2".into(),


### PR DESCRIPTION
Two main changes in this PR:
 * `network` module returns a `Configuration` object. When we run `ServerClient::get_configuration()` we already know which one is the `environment_id`, so we can use it to retrieve the `Configuration` object instead of the `ConfigurationJSON` one. **We hide JSON models from external modules**, we use our models in the (internal) interfaces.
 * Indeed, now the only consumer of `ConfigurationJSON` is our internal model `Configuration`. _Note.- It should probably be the other way around, JSON knows about the internal models, but that's a different change_.