### PR TITLE
[refact] Move metering into its own module

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -20,7 +20,6 @@ mod app_configuration_offline;
 pub(crate) mod configuration;
 pub(crate) mod feature_proxy;
 pub(crate) mod feature_snapshot;
-pub(crate) mod metering;
 pub(crate) mod property_proxy;
 pub(crate) mod property_snapshot;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,6 +85,7 @@ mod client;
 mod entity;
 mod errors;
 mod feature;
+pub(crate) mod metering;
 mod models;
 mod network;
 mod property;

--- a/src/metering/client.rs
+++ b/src/metering/client.rs
@@ -12,15 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod errors;
-pub(crate) mod http_client;
-mod token_provider;
+use super::MeteringResult;
+use crate::models::MeteringDataJson;
 
-pub(crate) use http_client::ServerClientImpl;
-pub use http_client::ServiceAddress;
-pub(crate) use token_provider::IBMCloudTokenProvider;
-pub use token_provider::TokenProvider;
-pub(crate) mod live_configuration;
-
-pub use errors::NetworkError;
-pub type NetworkResult<T> = std::result::Result<T, NetworkError>;
+pub(crate) trait MeteringClient: Send + 'static {
+    fn push_metering_data(&self, _data: &MeteringDataJson) -> MeteringResult<()> {
+        // Default implementation to make implementing mocks easier.
+        unimplemented!()
+    }
+}

--- a/src/metering/errors.rs
+++ b/src/metering/errors.rs
@@ -12,15 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod errors;
-pub(crate) mod http_client;
-mod token_provider;
+use thiserror::Error;
 
-pub(crate) use http_client::ServerClientImpl;
-pub use http_client::ServiceAddress;
-pub(crate) use token_provider::IBMCloudTokenProvider;
-pub use token_provider::TokenProvider;
-pub(crate) mod live_configuration;
-
-pub use errors::NetworkError;
-pub type NetworkResult<T> = std::result::Result<T, NetworkError>;
+#[derive(Debug, Error)]
+pub enum MeteringError {}

--- a/src/metering/mod.rs
+++ b/src/metering/mod.rs
@@ -1,4 +1,4 @@
-// (C) Copyright IBM Corp. 2024.
+// (C) Copyright IBM Corp. 2025.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,15 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod errors;
-pub(crate) mod http_client;
-mod token_provider;
+mod client;
+mod errors;
+mod metering;
 
-pub(crate) use http_client::ServerClientImpl;
-pub use http_client::ServiceAddress;
-pub(crate) use token_provider::IBMCloudTokenProvider;
-pub use token_provider::TokenProvider;
-pub(crate) mod live_configuration;
+pub(crate) use client::MeteringClient;
+pub(crate) use metering::start_metering;
 
-pub use errors::NetworkError;
-pub type NetworkResult<T> = std::result::Result<T, NetworkError>;
+pub type MeteringResult<T> = std::result::Result<T, errors::MeteringError>;

--- a/src/network/http_client.rs
+++ b/src/network/http_client.rs
@@ -14,7 +14,6 @@
 
 use super::{NetworkError, NetworkResult, TokenProvider};
 use crate::client::configuration::Configuration;
-use crate::models::MeteringDataJson;
 use crate::ConfigurationId;
 use reqwest::blocking::Client;
 use std::cell::RefCell;
@@ -104,11 +103,6 @@ pub trait ServerClient: Send + 'static {
         &self,
         collection: &ConfigurationId,
     ) -> NetworkResult<impl WebsocketReader>;
-
-    fn push_metering_data(&self, _data: &MeteringDataJson) -> NetworkResult<()> {
-        // Default implementation to make implementing mocks easier.
-        unimplemented!()
-    }
 }
 
 #[derive(Debug)]
@@ -215,10 +209,6 @@ impl ServerClient for ServerClientImpl {
 
         let (websocket, _) = connect(request)?;
         Ok(websocket)
-    }
-
-    fn push_metering_data(&self, _data: &MeteringDataJson) -> NetworkResult<()> {
-        todo!()
     }
 }
 


### PR DESCRIPTION
 * Moves all metering stuff into its own `metering` module
 * Extract from `ServerClient` trait the methods that are related to metering. Now they are in a new trait `MeteringClient`. In the implementation we will decide if it's the same object or different the one that implement these traits. It will _help_ to address [the issue we already envisioned](https://github.com/IBM/appconfiguration-rust-sdk/blob/068a5d1c0f9ef3f0f5f64509c1c0657ef7aefe05/src/client/app_configuration_http.rs#L51).