### PR TITLE
chore: Fix documentation warnings

### DIFF
--- a/src/client/app_configuration_http.rs
+++ b/src/client/app_configuration_http.rs
@@ -31,7 +31,7 @@ pub(crate) struct AppConfigurationClientHttp<T: LiveConfiguration> {
 }
 
 impl AppConfigurationClientHttp<LiveConfigurationImpl> {
-    /// Creates a new [`AppConfigurationClient`] connecting to the server specified in the constructor arguments
+    /// Creates a new [`crate::AppConfigurationClient`] connecting to the server specified in the constructor arguments
     ///
     /// This client keeps a websocket open to the server to receive live-updates
     /// to features and properties.

--- a/src/client/app_configuration_ibm_cloud.rs
+++ b/src/client/app_configuration_ibm_cloud.rs
@@ -29,7 +29,7 @@ pub struct AppConfigurationClientIBMCloud {
 }
 
 impl AppConfigurationClientIBMCloud {
-    /// Creates a new [`AppConfigurationClient`] connecting to IBM Cloud.
+    /// Creates a new [`crate::AppConfigurationClient`] connecting to IBM Cloud.
     ///
     /// This client keeps a websocket open to the server to receive live-updates
     /// to features and properties.

--- a/src/client/app_configuration_offline.rs
+++ b/src/client/app_configuration_offline.rs
@@ -26,7 +26,7 @@ pub struct AppConfigurationOffline {
 }
 
 impl AppConfigurationOffline {
-    /// Creates a new [`AppConfigurationClient`] taking the configuration from a local file.
+    /// Creates a new [`crate::AppConfigurationClient`] taking the configuration from a local file.
     ///
     /// # Arguments
     ///


### PR DESCRIPTION
When creating the docs, it was complaining about this `AppConfigurationClient` that was not in scope. Qualify the name so the link will be created properly.