### PR TITLE
feat: Add `use_private_endpoint` flag to IBM client

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2025-08-26T08:55:11Z",
+  "generated_at": "2025-09-26T14:19:47Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -82,7 +82,7 @@
         "hashed_secret": "fb34629c9af1ed4045b5d6f287426276b2be3a1e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 43,
+        "line_number": 73,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -99,23 +99,16 @@
     ],
     "src/network/token_provider.rs": [
       {
-        "hashed_secret": "91271e4ebcf7a9793e252299b9a2c77c8d964325",
+        "hashed_secret": "fb34629c9af1ed4045b5d6f287426276b2be3a1e",
         "is_verified": false,
         "line_number": 52,
         "type": "Secret Keyword",
         "verified_result": null
       },
       {
-        "hashed_secret": "fb34629c9af1ed4045b5d6f287426276b2be3a1e",
-        "is_verified": false,
-        "line_number": 56,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
         "hashed_secret": "3e4bdbe0b80e63c22b178576e906810777387b50",
         "is_verified": false,
-        "line_number": 196,
+        "line_number": 192,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ use appconfiguration::{
 
 // Create the client connecting to the server
 let configuration = ConfigurationId::new(guid, environment_id, collection_id);
-let client = AppConfigurationClientIBMCloud::new(&apikey, &region, configuration, OfflineMode::Fail)?;
+let client = AppConfigurationClientIBMCloud::new(&apikey, &region, configuration, OfflineMode::Fail, false)?;
 
 // Get the feature you want to evaluate for your entities
 let feature = client.get_feature("AB_testing_feature")?;

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -52,8 +52,13 @@ fn main() -> std::result::Result<(), Box<dyn Error>> {
     let property_id = env::var("PROPERTY_ID").expect("PROPERTY_ID should be set.");
 
     let configuration = ConfigurationId::new(guid, environment_id, collection_id);
-    let client =
-        AppConfigurationClientIBMCloud::new(&apikey, &region, configuration, OfflineMode::Fail)?;
+    let client = AppConfigurationClientIBMCloud::new(
+        &apikey,
+        &region,
+        configuration,
+        OfflineMode::Fail,
+        false,
+    )?;
 
     let entity = CustomerEntity {
         id: "user123".to_string(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,7 @@
 //!
 //! // Create the client connecting to the server
 //! let configuration = ConfigurationId::new(guid, environment_id, collection_id);
-//! let client = AppConfigurationClientIBMCloud::new(&apikey, &region, configuration, OfflineMode::Fail)?;
+//! let client = AppConfigurationClientIBMCloud::new(&apikey, &region, configuration, OfflineMode::Fail, false)?;
 //!
 //! // Get the feature you want to evaluate for your entities
 //! let feature = client.get_feature("AB_testing_feature")?;
@@ -101,7 +101,7 @@ pub use entity::Entity;
 pub use errors::{ConfigurationDataError, Error, Result};
 pub use feature::Feature;
 pub use network::live_configuration::OfflineMode;
-pub(crate) use network::{IBMCloudTokenProvider, ServerClientImpl};
+pub(crate) use network::{ServerClientImpl, TokenProviderImpl};
 pub use property::Property;
 pub use value::Value;
 

--- a/src/metering/client_http.rs
+++ b/src/metering/client_http.rs
@@ -63,7 +63,7 @@ pub(crate) mod tests {
     use httpmock::Method::POST;
     use httpmock::MockServer;
     use serde_json::json;
-    #[derive(Debug, Clone)]
+    #[derive(Default, Debug, Clone)]
     struct MockTokenProvider {}
 
     impl TokenProvider for MockTokenProvider {
@@ -97,7 +97,7 @@ pub(crate) mod tests {
 
         let client = MeteringClientHttp::new(
             ServiceAddress::new_without_ssl(server.host(), Some(server.port()), None),
-            Arc::new(Box::new(MockTokenProvider {})),
+            Arc::new(Box::new(MockTokenProvider::default())),
         );
 
         let data = MeteringDataJson::new("test".to_string(), "dev".to_string());
@@ -119,7 +119,7 @@ pub(crate) mod tests {
 
         let client = MeteringClientHttp::new(
             ServiceAddress::new_without_ssl(server.host(), Some(server.port()), None),
-            Arc::new(Box::new(MockTokenProvider {})),
+            Arc::new(Box::new(MockTokenProvider::default())),
         );
 
         let data = MeteringDataJson::new("test".to_string(), "dev".to_string());

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -19,8 +19,8 @@ mod token_provider;
 pub(crate) use http_client::ServerClientImpl;
 pub use http_client::ServiceAddress;
 pub(crate) use http_client::ServiceAddressProtocol;
-pub(crate) use token_provider::IBMCloudTokenProvider;
 pub use token_provider::TokenProvider;
+pub(crate) use token_provider::TokenProviderImpl;
 pub(crate) mod live_configuration;
 
 pub use errors::NetworkError;


### PR DESCRIPTION
close #105 

Add `use_private_endpoint` flag to `AppConfigurationClientIBMCloud::new` so users can choose to use VPE: https://cloud.ibm.com/docs/app-configuration?topic=app-configuration-ac-vpe&interface=ui&locale=en